### PR TITLE
REF: Style rework

### DIFF
--- a/nodeeditor/connection_geometry.py
+++ b/nodeeditor/connection_geometry.py
@@ -2,17 +2,17 @@ from qtpy.QtCore import QPointF, QRectF
 
 
 from .port import PortType
-from .style import StyleCollection
 
 
 class ConnectionGeometry:
-    def __init__(self):
+    def __init__(self, style):
         # local object coordinates
         self._in = QPointF(0, 0)
         self._out = QPointF(0, 0)
         # self._animationPhase = 0
         self._line_width = 3.0
         self._hovered = False
+        self._point_diameter = style.connection.point_diameter
 
     def get_end_point(self, port_type: PortType) -> QPointF:
         """
@@ -74,10 +74,9 @@ class ConnectionGeometry:
         c1, c2 = self.points_c1_c2()
         basic_rect = QRectF(self._out, self._in).normalized()
         c1c2_rect = QRectF(c1, c2).normalized()
-        connection_style = StyleCollection.connection_style()
-        diam = connection_style.point_diameter()
+
         common_rect = basic_rect.united(c1c2_rect)
-        corner_offset = QPointF(diam, diam)
+        corner_offset = QPointF(self._point_diameter, self._point_diameter)
         common_rect.setTopLeft(common_rect.topLeft() - corner_offset)
         common_rect.setBottomRight(common_rect.bottomRight() + 2 * corner_offset)
         return common_rect

--- a/nodeeditor/connection_graphics_object.py
+++ b/nodeeditor/connection_graphics_object.py
@@ -35,6 +35,7 @@ class ConnectionGraphicsObject(QGraphicsObject):
         self._connection = connection
         self._state = connection.connection_state()
         self._geometry = connection.connection_geometry()
+        self._style = connection.style.connection
 
         self._scene.addItem(self)
         self.setFlag(QGraphicsItem.ItemIsMovable, True)
@@ -144,7 +145,7 @@ class ConnectionGraphicsObject(QGraphicsObject):
         widget : QWidget
         """
         painter.setClipRect(option.exposedRect)
-        ConnectionPainter.paint(painter, self._connection)
+        ConnectionPainter.paint(painter, self._connection, self._style)
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent):
         """

--- a/nodeeditor/examples/style.py
+++ b/nodeeditor/examples/style.py
@@ -1,11 +1,9 @@
 import logging
 
-import qtpy
-from qtpy import QtCore, QtWidgets
+from qtpy import QtWidgets
 
 import nodeeditor
-from nodeeditor import FlowViewStyle, NodeStyle, ConnectionStyle, StyleCollection
-from nodeeditor import NodeData, NodeDataType, NodeDataModel
+from nodeeditor import NodeData, NodeDataType, NodeDataModel, StyleCollection
 
 
 style_json = '''
@@ -86,6 +84,7 @@ logging.basicConfig(level='DEBUG')
 app = QtWidgets.QApplication([])
 
 style = StyleCollection.from_json(style_json)
+# style = StyleCollection()
 model = MyDataModel(style=style)
 
 registry = nodeeditor.DataModelRegistry()
@@ -97,21 +96,6 @@ view.setWindowTitle("Style example")
 view.resize(800, 600)
 view.show()
 
-node1 = scene.create_node(model)
-node2 = scene.create_node(model)
-scene.create_connection(
-    node_in=node1, port_index_in=1,
-    node_out=node2, port_index_out=2,
-    converter=None
-)
-
-from nodeeditor import PortType
-
-# dtype = model.data_type(PortType.In, 0)
-# node1.react_to_possible_connection(
-#     reacting_port_type=PortType.In,
-#     reacting_data_type=model.data_type,
-#     scene_point=qtpy.QtCore.QPointF(0, 0),
-# )
+node = scene.create_node(model)
 
 app.exec_()

--- a/nodeeditor/flow_scene.py
+++ b/nodeeditor/flow_scene.py
@@ -5,6 +5,7 @@ from qtpy.QtCore import (QByteArray, QDir, QFile, QFileInfo, QIODevice,
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QFileDialog, QGraphicsScene
 
+from . import style as style_module
 from .connection import Connection
 from .connection_graphics_object import ConnectionGraphicsObject
 from .data_model_registry import DataModelRegistry
@@ -43,14 +44,29 @@ class FlowScene(QGraphicsScene):
     node_hovered = Signal(Node, QPoint)
     node_moved = Signal(Node, QPointF)
 
-    def __init__(self, registry=None, parent=None):
+    def __init__(self, registry=None, style=None, parent=None):
+        '''
+        Create a new flow scene
+
+        Parameters
+        ----------
+        registry : DataModelRegistry, optional
+        style : StyleCollection, optional
+        parent : QObject, optional
+        '''
         super().__init__(parent=parent)
         self._connections = []
         self._nodes = {}
+
         if registry is None:
             registry = DataModelRegistry()
 
+        if style is None:
+            style = style_module.default_style
+
+        self._style = style
         self._registry = registry
+
         self.setItemIndexMethod(QGraphicsScene.NoIndex)
 
         # self connection should come first
@@ -84,7 +100,8 @@ class FlowScene(QGraphicsScene):
         -------
         value : Connection
         """
-        connection = Connection.from_node(connected_port, node, port_index)
+        connection = Connection.from_node(connected_port, node, port_index,
+                                          style=self._style)
         cgo = ConnectionGraphicsObject(self, connection)
 
         # after self function connection points are set to node port
@@ -117,7 +134,8 @@ class FlowScene(QGraphicsScene):
         """
         connection = Connection.from_nodes(node_in, port_index_in,
                                            node_out, port_index_out,
-                                           converter=converter)
+                                           converter=converter,
+                                           style=self._style)
         cgo = ConnectionGraphicsObject(self, connection)
         node_in.node_state().set_connection(PortType.In, port_index_in, connection)
         node_out.node_state().set_connection(PortType.Out, port_index_out, connection)

--- a/nodeeditor/flow_view.py
+++ b/nodeeditor/flow_view.py
@@ -8,14 +8,14 @@ from qtpy.QtWidgets import QAction, QGraphicsView, QLineEdit, QMenu, QTreeWidget
 from .connection_graphics_object import ConnectionGraphicsObject
 from .flow_scene import FlowScene
 from .node_graphics_object import NodeGraphicsObject
-from .style import StyleCollection
+from . import style as style_module
 
 
 logger = logging.getLogger(__name__)
 
 
 class FlowView(QGraphicsView):
-    def __init__(self, scene, parent=None):
+    def __init__(self, scene, style=None, parent=None):
         super().__init__(parent=parent)
 
         self._clear_selection_action = None
@@ -26,9 +26,11 @@ class FlowView(QGraphicsView):
         self.setDragMode(QGraphicsView.ScrollHandDrag)
         self.setRenderHint(QPainter.Antialiasing)
 
-        style = StyleCollection.flow_view_style()
+        if style is None:
+            style = style_module.default_style
 
-        self.setBackgroundBrush(style.background_color)
+        self._style = style
+        self.setBackgroundBrush(style.flow_view.background_color)
 
         # setViewportUpdateMode(QGraphicsView.FullViewportUpdate)
         # setViewportUpdateMode(QGraphicsView.MinimalViewportUpdate)
@@ -297,13 +299,12 @@ class FlowView(QGraphicsView):
 
             painter.drawLines(lines)
 
-        flow_view_style = StyleCollection.flow_view_style()
-
+        style = self._style.flow_view
         brush = self.backgroundBrush()
-        pfine = QPen(flow_view_style.fine_grid_color, 1.0)
+        pfine = QPen(style.fine_grid_color, 1.0)
         painter.setPen(pfine)
         draw_grid(15)
-        p = QPen(flow_view_style.coarse_grid_color, 1.0)
+        p = QPen(style.coarse_grid_color, 1.0)
         painter.setPen(p)
         draw_grid(150)
 

--- a/nodeeditor/node.py
+++ b/nodeeditor/node.py
@@ -22,6 +22,7 @@ class Node(QObject, Serializable, NodeBase):
         super().__init__()
         self._node_data_model = data_model
         self._uid = QUuid.createUuid()
+        self._style = data_model.node_style()
         self._node_state = NodeState(self._node_data_model)
         self._node_geometry = NodeGeometry(self._node_data_model)
         self._node_graphics_object = None
@@ -82,9 +83,10 @@ class Node(QObject, Serializable, NodeBase):
         """
         return self._uid
 
-    def react_to_possible_connection(
-        self, reacting_port_type: PortType, reacting_data_type: NodeDataType, scene_point: QPointF
-    ):
+    def react_to_possible_connection(self, reacting_port_type: PortType,
+                                     reacting_data_type: NodeDataType,
+                                     scene_point: QPointF
+                                     ):
         """
         React to possible connection
 

--- a/nodeeditor/node_connection_interaction.py
+++ b/nodeeditor/node_connection_interaction.py
@@ -143,7 +143,10 @@ class NodeConnectionInteraction:
 
     def disconnect(self, port_to_disconnect: PortType) -> bool:
         """
-        1) Node and Connection should be already connected 2) If so, clear Connection entry in the NodeState 3) Propagate invalid data to IN node 4) Set Connection end to 'requiring a port'
+        1) Node and Connection should be already connected
+        2) If so, clear Connection entry in the NodeState
+        3) Propagate invalid data to IN node
+        4) Set Connection end to 'requiring a port'
 
         Parameters
         ----------
@@ -160,7 +163,7 @@ class NodeConnectionInteraction:
         state.erase_connection(port_to_disconnect, port_index,
                                self._connection)
 
-        # 4) Propagate invalid data to IN node
+        # Propagate invalid data to IN node
         self._connection.propagate_empty_data()
 
         # clear Connection side

--- a/nodeeditor/node_data.py
+++ b/nodeeditor/node_data.py
@@ -1,8 +1,8 @@
-from qtpy.QtCore import QObject, Qt
+from qtpy.QtCore import QObject
 from qtpy.QtWidgets import QWidget
 from qtpy.QtCore import Signal
 
-from .style import NodeStyle, StyleCollection
+from . import style as style_module
 from .enums import NodeValidationState, PortType, ConnectionPolicy
 from .serializable import Serializable
 from .port import PortIndex
@@ -57,11 +57,16 @@ class NodeDataModel(QObject, Serializable):
     computing_finished = Signal()
     embedded_widget_size_updated = Signal()
 
-    def __init__(self, node_style=None, parent=None):
+    def __init__(self, style=None, parent=None):
         super().__init__(parent=parent)
-        if node_style is None:
-            node_style = StyleCollection.node_style()
-        self._node_style = node_style
+        if style is None:
+            style = style_module.default_style
+        self._style = style
+
+    @property
+    def style(self):
+        'Style collection for drawing this data model'
+        return self._style
 
     def caption(self) -> str:
         """
@@ -176,7 +181,8 @@ class NodeDataModel(QObject, Serializable):
         """
         return ConnectionPolicy.Many
 
-    def node_style(self) -> NodeStyle:
+    # @property
+    def node_style(self) -> style_module.NodeStyle:
         """
         Node style
 
@@ -184,17 +190,7 @@ class NodeDataModel(QObject, Serializable):
         -------
         value : NodeStyle
         """
-        return self._node_style
-
-    def set_node_style(self, style: NodeStyle):
-        """
-        Set node style
-
-        Parameters
-        ----------
-        style : NodeStyle
-        """
-        self._node_style = style
+        return self._style.node
 
     def set_in_data(self, node_data: NodeData, port: PortIndex):
         """

--- a/nodeeditor/node_geometry.py
+++ b/nodeeditor/node_geometry.py
@@ -15,21 +15,20 @@ class NodeGeometry:
     def __init__(self, data_model: NodeDataModel):
         super().__init__()
         self._node_data_model = data_model
-        # some variables are mutable because we need to change drawing metrics
-        # corresponding to font_metrics but self doesn't change constness of
-        # Node
-        self._width = 100
-        self._height = 150
-        self._input_port_width = 70
-        self._output_port_width = 70
-        self._entry_height = 20
-        self._spacing = 20
-        self._hovered = False
-        self._n_sources = data_model.n_ports(PortType.Out)
-        self._n_sinks = data_model.n_ports(PortType.In)
-        self._dragging_pos = QPointF(-1000, -1000)
+
         self._data_model = data_model
+        self._dragging_pos = QPointF(-1000, -1000)
+        self._entry_height = 20
         self._font_metrics = QFontMetrics(QFont())
+        self._height = 150
+        self._hovered = False
+        self._input_port_width = 70
+        self._n_sinks = data_model.n_ports(PortType.In)
+        self._n_sources = data_model.n_ports(PortType.Out)
+        self._output_port_width = 70
+        self._spacing = 20
+        self._style = data_model.style.node
+        self._width = 100
 
         f = QFont()
         f.setBold(True)
@@ -215,8 +214,7 @@ class NodeGeometry:
         -------
         value : QRectF
         """
-        node_style = StyleCollection.node_style()
-        addon = 4 * node_style.connection_point_diameter
+        addon = 4 * self._style.connection_point_diameter
         return QRectF(0 - addon, 0 - addon,
                       self._width + 2 * addon, self._height + 2 * addon)
 
@@ -282,7 +280,7 @@ class NodeGeometry:
         """
         if t is None:
             t = QTransform()
-        node_style = StyleCollection.node_style()
+
         step = self._entry_height + self._spacing
 
         total_height = float(self.caption_height()) + step * index
@@ -290,10 +288,10 @@ class NodeGeometry:
         total_height += step / 2.0
 
         if port_type == PortType.Out:
-            x = self._width + node_style.connection_point_diameter
+            x = self._width + self._style.connection_point_diameter
             result = QPointF(x, total_height)
         elif port_type == PortType.In:
-            x = 0.0 - node_style.connection_point_diameter
+            x = 0.0 - self._style.connection_point_diameter
             result = QPointF(x, total_height)
         else:
             raise ValueError(port_type)
@@ -315,11 +313,10 @@ class NodeGeometry:
         -------
         value : PortIndex
         """
-        node_style = StyleCollection.node_style()
         if port_type == PortType.none:
             return INVALID
 
-        tolerance = 2.0 * node_style.connection_point_diameter
+        tolerance = 2.0 * self._style.connection_point_diameter
         for i in range(self._data_model.n_ports(port_type)):
             pp = self.port_scene_position(i, port_type, scene_transform)
             p = pp - scene_point

--- a/nodeeditor/node_graphics_object.py
+++ b/nodeeditor/node_graphics_object.py
@@ -31,7 +31,8 @@ class NodeGraphicsObject(QGraphicsObject):
 
         self.setCacheMode(QGraphicsItem.DeviceCoordinateCache)
 
-        node_style = node.node_data_model().node_style()
+        self._style = node.node_data_model().style
+        node_style = self._style.node
 
         effect = QGraphicsDropShadowEffect()
         effect.setOffset(4, 4)
@@ -119,7 +120,10 @@ class NodeGraphicsObject(QGraphicsObject):
         from .node_painter import NodePainter
         # TODO
         painter.setClipRect(option.exposedRect)
-        NodePainter.paint(painter, self._node, self._scene)
+        NodePainter.paint(painter, self._node, self._scene,
+                          node_style=self._style.node,
+                          connection_style=self._style.connection,
+                          )
 
     def itemChange(self, change: QGraphicsItem.GraphicsItemChange, value: QVariant) -> QVariant:
         """

--- a/nodeeditor/node_painter.py
+++ b/nodeeditor/node_painter.py
@@ -90,13 +90,17 @@ class NodePainter:
                          else node_style.pen_width))
         painter.setPen(p)
 
-        gradient = QLinearGradient(QPointF(0.0, 0.0), QPointF(2.0, geom.height()))
+        gradient = QLinearGradient(QPointF(0.0, 0.0),
+                                   QPointF(2.0, geom.height()))
         for at_, color in node_style.gradient_colors:
             gradient.setColorAt(at_, color)
         painter.setBrush(gradient)
 
         diam = node_style.connection_point_diameter
-        boundary = QRectF(-diam, -diam, 2.0 * diam + geom.width(), 2.0 * diam + geom.height())
+        boundary = QRectF(-diam,
+                          -diam,
+                          2.0 * diam + geom.width(),
+                          2.0 * diam + geom.height())
         radius = 3.0
         painter.drawRoundedRect(boundary, radius, radius)
 

--- a/nodeeditor/node_painter.py
+++ b/nodeeditor/node_painter.py
@@ -9,7 +9,7 @@ from .node_data import NodeDataModel
 from .node_geometry import NodeGeometry
 from .node_graphics_object import NodeGraphicsObject
 from .node_state import NodeState
-from .style import StyleCollection
+from .style import NodeStyle, ConnectionStyle
 
 
 class NodePainterDelegate:
@@ -28,7 +28,8 @@ class NodePainterDelegate:
 
 class NodePainter:
     @staticmethod
-    def paint(painter: QPainter, node: NodeBase, scene: FlowSceneBase):
+    def paint(painter: QPainter, node: NodeBase, scene: FlowSceneBase,
+              node_style: NodeStyle, connection_style: ConnectionStyle):
         """
         Paint
 
@@ -37,6 +38,8 @@ class NodePainter:
         painter : QPainter
         node : Node
         scene : FlowScene
+        node_style : NodeStyle
+        connection_style : ConnectionStyle
         """
         geom = node.node_geometry()
         state = node.node_state()
@@ -44,13 +47,18 @@ class NodePainter:
         geom.recalculate_size(painter.font())
 
         model = node.node_data_model()
-        NodePainter.draw_node_rect(painter, geom, model, graphics_object)
-        NodePainter.draw_connection_points(painter, geom, state, model, scene)
-        NodePainter.draw_filled_connection_points(painter, geom, state, model)
-        NodePainter.draw_model_name(painter, geom, state, model)
-        NodePainter.draw_entry_labels(painter, geom, state, model)
+        NodePainter.draw_node_rect(painter, geom, model, graphics_object,
+                                   node_style)
+        NodePainter.draw_connection_points(painter, geom, state, model, scene,
+                                           node_style, connection_style)
+        NodePainter.draw_filled_connection_points(painter, geom, state, model,
+                                                  node_style, connection_style
+                                                  )
+        NodePainter.draw_model_name(painter, geom, state, model, node_style)
+        NodePainter.draw_entry_labels(painter, geom, state, model, node_style)
         NodePainter.draw_resize_rect(painter, geom, model)
-        NodePainter.draw_validation_rect(painter, geom, model, graphics_object)
+        NodePainter.draw_validation_rect(painter, geom, model, graphics_object,
+                                         node_style)
 
         # call custom painter
         painter_delegate = model.painter_delegate()
@@ -58,8 +66,10 @@ class NodePainter:
             painter_delegate.paint(painter, geom, model)
 
     @staticmethod
-    def draw_node_rect(painter: QPainter, geom: NodeGeometry, model:
-                       NodeDataModel, graphics_object: NodeGraphicsObject):
+    def draw_node_rect(painter: QPainter, geom: NodeGeometry,
+                       model: NodeDataModel,
+                       graphics_object: NodeGraphicsObject,
+                       node_style: NodeStyle):
         """
         Draw node rect
 
@@ -69,8 +79,8 @@ class NodePainter:
         geom : NodeGeometry
         model : NodeDataModel
         graphics_object : NodeGraphicsObject
+        node_style : NodeStyle
         """
-        node_style = model.node_style()
         color = (node_style.selected_boundary_color
                  if graphics_object.isSelected()
                  else node_style.normal_boundary_color
@@ -81,10 +91,8 @@ class NodePainter:
         painter.setPen(p)
 
         gradient = QLinearGradient(QPointF(0.0, 0.0), QPointF(2.0, geom.height()))
-        gradient.setColorAt(0.0, node_style.gradient_color0)
-        gradient.setColorAt(0.03, node_style.gradient_color1)
-        gradient.setColorAt(0.97, node_style.gradient_color2)
-        gradient.setColorAt(1.0, node_style.gradient_color3)
+        for at_, color in node_style.gradient_colors:
+            gradient.setColorAt(at_, color)
         painter.setBrush(gradient)
 
         diam = node_style.connection_point_diameter
@@ -95,7 +103,8 @@ class NodePainter:
     @staticmethod
     def draw_model_name(painter: QPainter, geom: NodeGeometry,
                         state: NodeState,
-                        model: NodeDataModel):
+                        model: NodeDataModel,
+                        node_style: NodeStyle):
         """
         Draw model name
 
@@ -106,7 +115,6 @@ class NodePainter:
         state : NodeState
         model : NodeDataModel
         """
-        node_style = model.node_style()
         if not model.caption_visible():
             return
         name = model.caption()
@@ -123,7 +131,9 @@ class NodePainter:
         painter.setFont(f)
 
     @staticmethod
-    def draw_entry_labels(painter: QPainter, geom: NodeGeometry, state: NodeState, model: NodeDataModel):
+    def draw_entry_labels(painter: QPainter, geom: NodeGeometry,
+                          state: NodeState, model: NodeDataModel,
+                          node_style: NodeStyle):
         """
         Draw entry labels
 
@@ -133,11 +143,10 @@ class NodePainter:
         geom : NodeGeometry
         state : NodeState
         model : NodeDataModel
+        node_style : NodeStyle
         """
         metrics = painter.fontMetrics()
         for port_type in (PortType.Out, PortType.In):
-            node_style = model.node_style()
-
             for i, entries in enumerate(state.get_entries(port_type)):
                 p = geom.port_scene_position(i, port_type)
                 if not entries:
@@ -160,9 +169,11 @@ class NodePainter:
                 painter.drawText(p, s)
 
     @staticmethod
-    def draw_connection_points(
-        painter: QPainter, geom: NodeGeometry, state: NodeState, model: NodeDataModel, scene: FlowSceneBase
-    ):
+    def draw_connection_points(painter: QPainter, geom: NodeGeometry,
+                               state: NodeState, model: NodeDataModel,
+                               scene: FlowSceneBase, node_style: NodeStyle,
+                               connection_style: ConnectionStyle
+                               ):
         """
         Draw connection points
 
@@ -173,9 +184,8 @@ class NodePainter:
         state : NodeState
         model : NodeDataModel
         scene : FlowScene
+        connection_style : ConnectionStyle
         """
-        node_style = model.node_style()
-        connection_style = StyleCollection.connection_style()
         diameter = node_style.connection_point_diameter
         reduced_diameter = diameter * 0.6
         for port_type in (PortType.Out, PortType.In):
@@ -215,15 +225,20 @@ class NodePainter:
                              if dist < thres
                              else 1.0)
 
-                if connection_style.use_data_defined_colors():
-                    painter.setBrush(connection_style.normal_color(data_type.id))
+                if connection_style.use_data_defined_colors:
+                    painter.setBrush(connection_style.get_normal_color(data_type.id))
                 else:
                     painter.setBrush(node_style.connection_point_color)
 
                 painter.drawEllipse(p, reduced_diameter * r, reduced_diameter * r)
 
     @staticmethod
-    def draw_filled_connection_points(painter: QPainter, geom: NodeGeometry, state: NodeState, model: NodeDataModel):
+    def draw_filled_connection_points(painter: QPainter, geom: NodeGeometry,
+                                      state: NodeState, model: NodeDataModel,
+                                      node_style: NodeStyle,
+                                      connection_style: ConnectionStyle
+                                      ):
+
         """
         Draw filled connection points
 
@@ -233,9 +248,9 @@ class NodePainter:
         geom : NodeGeometry
         state : NodeState
         model : NodeDataModel
+        node_style : NodeStyle
+        connection_style : ConnectionStyle
         """
-        node_style = model.node_style()
-        connection_style = StyleCollection.connection_style()
         diameter = node_style.connection_point_diameter
         for port_type in (PortType.Out, PortType.In):
             for i, entries in enumerate(state.get_entries(port_type)):
@@ -244,8 +259,8 @@ class NodePainter:
 
                 p = geom.port_scene_position(i, port_type)
                 data_type = model.data_type(port_type, i)
-                if connection_style.use_data_defined_colors():
-                    c = connection_style.normal_color(data_type.id)
+                if connection_style.use_data_defined_colors:
+                    c = connection_style.get_normal_color(data_type.id)
                 else:
                     c = node_style.filled_connection_point_color
                 painter.setPen(c)
@@ -268,9 +283,10 @@ class NodePainter:
             painter.drawEllipse(geom.resize_rect())
 
     @staticmethod
-    def draw_validation_rect(
-        painter: QPainter, geom: NodeGeometry, model: NodeDataModel, graphics_object: NodeGraphicsObject
-    ):
+    def draw_validation_rect(painter: QPainter, geom: NodeGeometry,
+                             model: NodeDataModel,
+                             graphics_object: NodeGraphicsObject,
+                             node_style: NodeStyle):
         """
         Draw validation rect
 
@@ -280,13 +296,15 @@ class NodePainter:
         geom : NodeGeometry
         model : NodeDataModel
         graphics_object : NodeGraphicsObject
+        node_style : NodeStyle
         """
         model_validation_state = model.validation_state()
         if model_validation_state == NodeValidationState.Valid:
             return
 
-        node_style = model.node_style()
-        color = node_style.selected_boundary_color if graphics_object.isSelected() else node_style.normal_boundary_color
+        color = (node_style.selected_boundary_color
+                 if graphics_object.isSelected()
+                 else node_style.normal_boundary_color)
 
         if geom.hovered():
             p = QPen(color, node_style.hovered_pen_width)

--- a/nodeeditor/style.py
+++ b/nodeeditor/style.py
@@ -1,9 +1,7 @@
-import pathlib
 import json
 import logging
 import random
 
-from qtpy.QtCore import QByteArray, QFile, QIODevice, QJsonDocument, QJsonValue
 from qtpy.QtGui import QColor
 
 
@@ -22,74 +20,81 @@ def _get_qcolor(style_dict, key):
 
 
 class Style:
-    default_json = pathlib.Path(__file__).parent / 'DefaultStyle.json'
+    default_style = {
+        "FlowViewStyle": {
+            "BackgroundColor": [53, 53, 53],
+            "FineGridColor": [60, 60, 60],
+            "CoarseGridColor": [25, 25, 25]
+        },
+        "NodeStyle": {
+            "NormalBoundaryColor": [255, 255, 255],
+            "SelectedBoundaryColor": [255, 165, 0],
+            "GradientColor0": "gray",
+            "GradientColor1": [80, 80, 80],
+            "GradientColor2": [64, 64, 64],
+            "GradientColor3": [58, 58, 58],
+            "ShadowColor": [20, 20, 20],
+            "FontColor": "white",
+            "FontColorFaded": "gray",
+            "ConnectionPointColor": [169, 169, 169],
+            "FilledConnectionPointColor": "cyan",
+            "ErrorColor": "red",
+            "WarningColor": [128, 128, 0],
 
-    def __init__(self, json_text=None):
-        if json_text:
-            self.load_json_text(json_text)
-        else:
-            self.load_json_file(self.default_json)
+            "PenWidth": 1.0,
+            "HoveredPenWidth": 1.5,
 
-    def load_json_text(self, json_text: str):
-        """
-        Load json text
+            "ConnectionPointDiameter": 8.0,
 
-        Parameters
-        ----------
-        json_text : str
-        """
-        self.load_from_json(json_text)
+            "Opacity": 0.8
+        },
+        "ConnectionStyle": {
+            "ConstructionColor": "gray",
+            "NormalColor": "darkcyan",
+            "SelectedColor": [100, 100, 100],
+            "SelectedHaloColor": "orange",
+            "HoveredColor": "lightcyan",
+            "LineWidth": 3.0,
+            "ConstructionLineWidth": 2.0,
+            "PointDiameter": 10.0,
+            "UseDataDefinedColors": False
+        }
+    }
 
-    def load_json_file(self, file_name: str):
-        """
-        Load json file
+    def __init__(self, json_style=None):
+        if json_style:
+            self.load_from_json(json_style)
 
-        Parameters
-        ----------
-        file_name : str
-        """
-        with open(file_name, 'rt') as f:
-            self.load_from_json(f.read())
-
-    def load_from_json(self, byte_array: QByteArray):
+    def load_from_json(self, json_style: str):
         """
         Load from json
 
         Parameters
         ----------
-        byte_array : QByteArray
+        json_style : str or dict
         """
-        ...
+        if isinstance(json_style, dict):
+            return json_style
+        else:
+            return json.loads(json_style)
 
 
 class FlowViewStyle(Style):
-    def __init__(self, json_text=None):
+    def __init__(self, json_style=None):
         self.background_color = QColor()
         self.fine_grid_color = QColor()
         self.coarse_grid_color = QColor()
-        super().__init__(json_text=json_text)
+        super().__init__(json_style=json_style)
 
-    @staticmethod
-    def set_style(json_text: str):
-        """
-        Set style
-
-        Parameters
-        ----------
-        json_text : str
-        """
-        style = FlowViewStyle(json_text)
-        StyleCollection.set_flow_view_style(style)
-
-    def load_from_json(self, byte_array: QByteArray):
+    def load_from_json(self, json_style: str):
         """
         Load from json
 
         Parameters
         ----------
-        byte_array : QByteArray
+        json_style : str or dict
         """
-        doc = json.loads(byte_array)
+        doc = super().load_from_json(json_style)
         style = doc["FlowViewStyle"]
         self.background_color = _get_qcolor(style, 'BackgroundColor')
         self.fine_grid_color = _get_qcolor(style, 'FineGridColor')
@@ -97,65 +102,59 @@ class FlowViewStyle(Style):
 
 
 class ConnectionStyle(Style):
-    def __init__(self, json_text=None):
-        self._construction_color = QColor()
-        self._normal_color = QColor()
-        self._selected_color = QColor()
-        self._selected_halo_color = QColor()
-        self._hovered_color = QColor()
+    '''
+    Style for connections
 
-        self._line_width = 0.0
-        self._construction_line_width = 0.0
-        self._point_diameter = 0.0
+    Attributes
+    ----------
+    construction_color : QColor
+    normal_color : QColor
+    selected_color : QColor
+    selected_halo_color : QColor
+    hovered_color : QColor
+    line_width : float
+    construction_line_width : float
+    point_diameter : float
+    use_data_defined_colors : bool
+    '''
 
-        self._use_data_defined_colors = True
+    def __init__(self, json_style=None):
+        self.construction_color = QColor()
+        self.normal_color = QColor()
+        self.selected_color = QColor()
+        self.selected_halo_color = QColor()
+        self.hovered_color = QColor()
 
-        super().__init__(json_text=json_text)
+        self.line_width = 0.0
+        self.construction_line_width = 0.0
+        self.point_diameter = 0.0
 
-    @staticmethod
-    def set_connection_style(json_text: str):
-        """
-        Set connection style
+        self.use_data_defined_colors = True
 
-        Parameters
-        ----------
-        json_text : str
-        """
-        style = ConnectionStyle(json_text)
-        StyleCollection.set_connection_style(style)
+        super().__init__(json_style=json_style)
 
-    def load_from_json(self, byte_array: QByteArray):
+    def load_from_json(self, json_style: str):
         """
         Load from json
 
         Parameters
         ----------
-        byte_array : QByteArray
+        json_style : str
         """
-        doc = json.loads(byte_array)
+        doc = super().load_from_json(json_style)
         style = doc["ConnectionStyle"]
-        self._construction_color = _get_qcolor(style, 'ConstructionColor')
-        self._normal_color = _get_qcolor(style, 'NormalColor')
-        self._selected_color = _get_qcolor(style, 'SelectedColor')
-        self._selected_halo_color = _get_qcolor(style, 'SelectedHaloColor')
-        self._hovered_color = _get_qcolor(style, 'HoveredColor')
+        self.construction_color = _get_qcolor(style, 'ConstructionColor')
+        self.normal_color = _get_qcolor(style, 'NormalColor')
+        self.selected_color = _get_qcolor(style, 'SelectedColor')
+        self.selected_halo_color = _get_qcolor(style, 'SelectedHaloColor')
+        self.hovered_color = _get_qcolor(style, 'HoveredColor')
 
-        self._line_width = float(style['LineWidth'])
-        self._construction_line_width = float(style['ConstructionLineWidth'])
-        self._point_diameter = float(style['PointDiameter'])
-        self._use_data_defined_colors = bool(style['UseDataDefinedColors'])
+        self.line_width = float(style['LineWidth'])
+        self.construction_line_width = float(style['ConstructionLineWidth'])
+        self.point_diameter = float(style['PointDiameter'])
+        self.use_data_defined_colors = bool(style['UseDataDefinedColors'])
 
-    def construction_color(self) -> QColor:
-        """
-        Construction color
-
-        Returns
-        -------
-        value : QColor
-        """
-        return self._construction_color
-
-    def normal_color(self, type_id: str = None) -> QColor:
+    def get_normal_color(self, type_id: str = None) -> QColor:
         """
         Normal color
 
@@ -176,7 +175,7 @@ class ConnectionStyle(Style):
         #   return QColor::fromHsl(hue, sat, 160);
         # }
         if type_id is None:
-            return self._normal_color
+            return self.normal_color
 
         hash = id(type_id)
         hue_range = 0xFF
@@ -185,85 +184,12 @@ class ConnectionStyle(Style):
         sat = 120 + hash % 129
         return QColor.fromHsl(hue, sat, 160)
 
-    def selected_color(self) -> QColor:
-        """
-        Selected color
-
-        Returns
-        -------
-        value : QColor
-        """
-        return self._selected_color
-
-    def selected_halo_color(self) -> QColor:
-        """
-        Selected halo color
-
-        Returns
-        -------
-        value : QColor
-        """
-        return self._selected_halo_color
-
-    def hovered_color(self) -> QColor:
-        """
-        Hovered color
-
-        Returns
-        -------
-        value : QColor
-        """
-        return self._hovered_color
-
-    def line_width(self) -> float:
-        """
-        Line width
-
-        Returns
-        -------
-        value : float
-        """
-        return self._line_width
-
-    def construction_line_width(self) -> float:
-        """
-        Construction line width
-
-        Returns
-        -------
-        value : float
-        """
-        return self._construction_line_width
-
-    def point_diameter(self) -> float:
-        """
-        Point diameter
-
-        Returns
-        -------
-        value : float
-        """
-        return self._point_diameter
-
-    def use_data_defined_colors(self) -> bool:
-        """
-        Use data defined colors
-
-        Returns
-        -------
-        value : bool
-        """
-        return self._use_data_defined_colors
-
 
 class NodeStyle(Style):
-    def __init__(self, json_text=None):
+    def __init__(self, json_style=None):
         self.normal_boundary_color = QColor()
         self.selected_boundary_color = QColor()
-        self.gradient_color0 = QColor()
-        self.gradient_color1 = QColor()
-        self.gradient_color2 = QColor()
-        self.gradient_color3 = QColor()
+        self.gradient_colors = [QColor()]
         self.shadow_color = QColor()
         self.font_color = QColor()
         self.font_color_faded = QColor()
@@ -279,132 +205,73 @@ class NodeStyle(Style):
         self.connection_point_diameter = 5.0
         self.opacity = 1.0
 
-        super().__init__(json_text=json_text)
+        super().__init__(json_style=json_style)
 
-    @staticmethod
-    def set_node_style(json_text: str):
-        """
-        Set node style
-
-        Parameters
-        ----------
-        json_text : str
-        """
-        style = NodeStyle(json_text)
-        StyleCollection.set_node_style(style)
-
-    def load_from_json(self, byte_array: QByteArray):
+    def load_from_json(self, json_style: str):
         """
         Load from json
 
         Parameters
         ----------
-        byte_array : QByteArray
+        json_style : str
         """
-        doc = json.loads(byte_array)
+        doc = super().load_from_json(json_style)
         style = doc["NodeStyle"]
 
         self.normal_boundary_color = _get_qcolor(style, 'NormalBoundaryColor')
-        self.selected_boundary_color = _get_qcolor(style, 'SelectedBoundaryColor')
-        self.gradient_color0 = _get_qcolor(style, 'GradientColor0')
-        self.gradient_color1 = _get_qcolor(style, 'GradientColor1')
-        self.gradient_color2 = _get_qcolor(style, 'GradientColor2')
-        self.gradient_color3 = _get_qcolor(style, 'GradientColor3')
+        self.selected_boundary_color = _get_qcolor(
+            style, 'SelectedBoundaryColor')
+        self.gradient_colors = (
+            (0.0, _get_qcolor(style, 'GradientColor0')),
+            (0.03, _get_qcolor(style, 'GradientColor1')),
+            (0.97, _get_qcolor(style, 'GradientColor2')),
+            (1.0, _get_qcolor(style, 'GradientColor3')),
+        )
         self.shadow_color = _get_qcolor(style, 'ShadowColor')
         self.font_color = _get_qcolor(style, 'FontColor')
         self.font_color_faded = _get_qcolor(style, 'FontColorFaded')
-        self.connection_point_color = _get_qcolor(style, 'ConnectionPointColor')
-        self.filled_connection_point_color = _get_qcolor(style, 'FilledConnectionPointColor')
+        self.connection_point_color = _get_qcolor(
+            style, 'ConnectionPointColor')
+        self.filled_connection_point_color = _get_qcolor(
+            style, 'FilledConnectionPointColor')
         self.warning_color = _get_qcolor(style, 'WarningColor')
         self.error_color = _get_qcolor(style, 'ErrorColor')
 
         self.pen_width = float(style['PenWidth'])
         self.hovered_pen_width = float(style['HoveredPenWidth'])
-        self.connection_point_diameter = float(style['ConnectionPointDiameter'])
+        self.connection_point_diameter = float(
+            style['ConnectionPointDiameter'])
         self.opacity = float(style['Opacity'])
 
 
 class StyleCollection:
-    _node_style = NodeStyle()
-    _connection_style = ConnectionStyle()
-    _flow_view_style = FlowViewStyle()
+    'Container for all styles'
 
-    @staticmethod
-    def node_style() -> NodeStyle:
-        """
-        Node style
+    def __init__(self, *, node=None, connection=None, flow_view=None):
+        if node is None:
+            node = NodeStyle()
+        self.node = node
 
-        Returns
-        -------
-        value : NodeStyle
-        """
-        return _style_collection._node_style
+        if connection is None:
+            connection = ConnectionStyle()
+        self.connection = connection
 
-    @staticmethod
-    def connection_style() -> ConnectionStyle:
-        """
-        Connection style
+        if flow_view is None:
+            flow_view = FlowViewStyle()
+        self.flow_view = flow_view
 
-        Returns
-        -------
-        value : ConnectionStyle
-        """
-        return _style_collection._connection_style
+    @classmethod
+    def from_json(cls, json_doc):
+        if isinstance(json_doc, dict):
+            json_style = json_doc
+        else:
+            json_style = json.loads(json_doc)
 
-    @staticmethod
-    def flow_view_style() -> FlowViewStyle:
-        """
-        Flow view style
-
-        Returns
-        -------
-        value : FlowViewStyle
-        """
-        return _style_collection._flow_view_style
-
-    @staticmethod
-    def set_node_style(node_style: NodeStyle):
-        """
-        Set node style
-
-        Parameters
-        ----------
-        node_style : NodeStyle
-        """
-        _style_collection._node_style = node_style
-
-    @staticmethod
-    def set_connection_style(connection_style: ConnectionStyle):
-        """
-        Set connection style
-
-        Parameters
-        ----------
-        connection_style : ConnectionStyle
-        """
-        _style_collection._connection_style = connection_style
-
-    @staticmethod
-    def set_flow_view_style(flow_view_style: FlowViewStyle):
-        """
-        Set flow view style
-
-        Parameters
-        ----------
-        flow_view_style : FlowViewStyle
-        """
-        _style_collection._flow_view_style = flow_view_style
-
-    @staticmethod
-    def instance():
-        """
-        Instance
-
-        Returns
-        -------
-        value : StyleCollection
-        """
-        return _style_collection
+        return StyleCollection(
+            node=NodeStyle(json_style),
+            connection=ConnectionStyle(json_style),
+            flow_view=FlowViewStyle(json_style),
+        )
 
 
-_style_collection = StyleCollection()
+default_style = StyleCollection()

--- a/nodeeditor/style.py
+++ b/nodeeditor/style.py
@@ -14,9 +14,12 @@ def _get_qcolor(style_dict, key):
 
     name_or_list = style_dict[key]
     if isinstance(name_or_list, list):
-        return QColor(*name_or_list)
-
-    return QColor(name_or_list)
+        color = QColor(*name_or_list)
+    else:
+        color = QColor(name_or_list)
+    logger.debug('Loaded color %s = %s -> %d %d %d %d', key, name_or_list,
+                 *color.getRgb())
+    return color
 
 
 class Style:
@@ -62,8 +65,10 @@ class Style:
     }
 
     def __init__(self, json_style=None):
-        if json_style:
-            self.load_from_json(json_style)
+        if json_style is None:
+            json_style = self.default_style
+
+        self.load_from_json(json_style)
 
     def load_from_json(self, json_style: str):
         """
@@ -189,7 +194,7 @@ class NodeStyle(Style):
     def __init__(self, json_style=None):
         self.normal_boundary_color = QColor()
         self.selected_boundary_color = QColor()
-        self.gradient_colors = [QColor()]
+        self.gradient_colors = ((0, QColor()), )
         self.shadow_color = QColor()
         self.font_color = QColor()
         self.font_color_faded = QColor()

--- a/test.py
+++ b/test.py
@@ -1,66 +1,53 @@
 import logging
-import nodeeditor
-from nodeeditor import FlowViewStyle, NodeStyle, ConnectionStyle, StyleCollection
 
 import qtpy
 from qtpy import QtCore, QtWidgets
 
-
-def set_style():
-
-    FlowViewStyle.set_style('''
-  {
-    "FlowViewStyle": {
-      "BackgroundColor": [255, 255, 240],
-      "FineGridColor": [245, 245, 230],
-      "CoarseGridColor": [235, 235, 220]
-    }
-  }
-''')
-
-    NodeStyle.set_node_style(
-    '''
-  {
-    "NodeStyle": {
-      "NormalBoundaryColor": "darkgray",
-      "SelectedBoundaryColor": "deepskyblue",
-      "GradientColor0": "mintcream",
-      "GradientColor1": "mintcream",
-      "GradientColor2": "mintcream",
-      "GradientColor3": "mintcream",
-      "ShadowColor": [200, 200, 200],
-      "FontColor": [10, 10, 10],
-      "FontColorFaded": [100, 100, 100],
-      "ConnectionPointColor": "white",
-      "PenWidth": 2.0,
-      "HoveredPenWidth": 2.5,
-      "ConnectionPointDiameter": 10.0,
-      "Opacity": 1.0
-    }
-  }
-''')
-
-    ConnectionStyle.set_connection_style(
-        '''
-  {
-    "ConnectionStyle": {
-      "ConstructionColor": "gray",
-      "NormalColor": "black",
-      "SelectedColor": "gray",
-      "SelectedHaloColor": "deepskyblue",
-      "HoveredColor": "deepskyblue",
-
-      "LineWidth": 3.0,
-      "ConstructionLineWidth": 2.0,
-      "PointDiameter": 10.0,
-
-      "UseDataDefinedColors": false
-    }
-  }'''
-    )
-
-
+import nodeeditor
+from nodeeditor import FlowViewStyle, NodeStyle, ConnectionStyle, StyleCollection
 from nodeeditor import NodeData, NodeDataType, NodeDataModel
+
+
+style_json = '''
+    {
+      "FlowViewStyle": {
+        "BackgroundColor": [255, 255, 240],
+        "FineGridColor": [245, 245, 230],
+        "CoarseGridColor": [235, 235, 220]
+      },
+      "NodeStyle": {
+        "NormalBoundaryColor": "darkgray",
+        "SelectedBoundaryColor": "deepskyblue",
+        "GradientColor0": "mintcream",
+        "GradientColor1": "mintcream",
+        "GradientColor2": "mintcream",
+        "GradientColor3": "mintcream",
+        "ShadowColor": [200, 200, 200],
+        "FontColor": [10, 10, 10],
+        "FontColorFaded": [100, 100, 100],
+        "ConnectionPointColor": "white",
+        "PenWidth": 2.0,
+        "HoveredPenWidth": 2.5,
+        "ConnectionPointDiameter": 10.0,
+        "Opacity": 1.0
+      },
+      "ConnectionStyle": {
+        "ConstructionColor": "gray",
+        "NormalColor": "black",
+        "SelectedColor": "gray",
+        "SelectedHaloColor": "deepskyblue",
+        "HoveredColor": "deepskyblue",
+
+        "LineWidth": 3.0,
+        "ConstructionLineWidth": 2.0,
+        "PointDiameter": 10.0,
+
+        "UseDataDefinedColors": false
+      }
+  }
+'''
+
+
 
 class MyNodeData(NodeData):
     _type = NodeDataType('MyNodeData', 'My Node Data')
@@ -94,19 +81,15 @@ class MyDataModel(NodeDataModel):
     def embedded_widget(self):
         return None
 
-    # def node_style(self):
-    #     return StyleCollection.instance().node_style()
-
 
 logging.basicConfig(level='DEBUG')
 app = QtWidgets.QApplication([])
-model = MyDataModel()
+
+style = StyleCollection.from_json(style_json)
+model = MyDataModel(style=style)
 
 registry = nodeeditor.DataModelRegistry()
 registry.register_model(model, category='My Category')
-
-set_style()
-
 scene = nodeeditor.FlowScene(registry=registry)
 
 view = nodeeditor.FlowView(scene)
@@ -114,8 +97,21 @@ view.setWindowTitle("Style example")
 view.resize(800, 600)
 view.show()
 
-scene.create_node(model)
-scene.save('test.flow')
-scene.clear_scene()
-scene.load('test.flow')
+node1 = scene.create_node(model)
+node2 = scene.create_node(model)
+scene.create_connection(
+    node_in=node1, port_index_in=1,
+    node_out=node2, port_index_out=2,
+    converter=None
+)
+
+from nodeeditor import PortType
+
+# dtype = model.data_type(PortType.In, 0)
+# node1.react_to_possible_connection(
+#     reacting_port_type=PortType.In,
+#     reacting_data_type=model.data_type,
+#     scene_point=qtpy.QtCore.QPointF(0, 0),
+# )
+
 app.exec_()


### PR DESCRIPTION
* `StyleCollection` instance can be passed around and used more easily now.
* No longer relies on the odd singleton pattern from the C++ version.
* Move `style.py` to `nodeeditor.examples`
