### PR TITLE
Add connection colors example

### DIFF
--- a/qtpynodeeditor/examples/__init__.py
+++ b/qtpynodeeditor/examples/__init__.py
@@ -1,5 +1,6 @@
 from . import calculator
 from . import style
+from . import connection_colors
 
 
-__all__ = ['calculator', 'style']
+__all__ = ['calculator', 'style', 'connection_colors']

--- a/qtpynodeeditor/examples/connection_colors.py
+++ b/qtpynodeeditor/examples/connection_colors.py
@@ -1,0 +1,79 @@
+import logging
+
+from qtpy import QtWidgets
+
+import qtpynodeeditor
+from qtpynodeeditor import (NodeData, NodeDataType, NodeDataModel, PortType)
+
+
+class MyNodeData(NodeData):
+    data_type = NodeDataType(id='MyNodeData', name='My Node Data')
+
+
+class SimpleNodeData(NodeData):
+    data_type = NodeDataType(id='SimpleData', name='Simple Data')
+
+
+class NaiveDataModel(NodeDataModel):
+    name = 'NaiveDataModel'
+    caption = 'Caption'
+    caption_visible = True
+    num_ports = {PortType.input: 2,
+                 PortType.output: 2,
+                 }
+
+    def data_type(self, port_type, port_index):
+        return {0: MyNodeData.data_type,
+                1: SimpleNodeData.data_type}[port_index]
+
+    def out_data(self, port_index):
+        if port_index == 0:
+            return MyNodeData()
+        elif port_index == 1:
+            return SimpleNodeData()
+
+    def set_in_data(self, node_data, port):
+        ...
+
+    def embedded_widget(self):
+        ...
+
+
+def main(app):
+    registry = qtpynodeeditor.DataModelRegistry()
+    registry.register_model(NaiveDataModel, category='My Category')
+    scene = qtpynodeeditor.FlowScene(registry=registry)
+
+    connection_style = scene.style_collection.connection
+
+    # Configure the style collection to use colors based on data types:
+    connection_style.use_data_defined_colors = True
+
+    view = qtpynodeeditor.FlowView(scene)
+    view.setWindowTitle("Connection (data-defined) color example")
+    view.resize(800, 600)
+
+    node_a = scene.create_node(NaiveDataModel)
+    node_b = scene.create_node(NaiveDataModel)
+
+    scene.create_connection(
+        node_out=node_a, port_index_out=0,
+        node_in=node_b, port_index_in=0,
+        converter=None
+    )
+
+    scene.create_connection(
+        node_out=node_a, port_index_out=1,
+        node_in=node_b, port_index_in=1,
+        converter=None
+    )
+
+    return scene, view, [node_a, node_b]
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level='DEBUG')
+    app = QtWidgets.QApplication([])
+    scene, view, nodes = main(app)
+    view.show()
+    app.exec_()

--- a/qtpynodeeditor/examples/style.py
+++ b/qtpynodeeditor/examples/style.py
@@ -59,13 +59,10 @@ class MyDataModel(NodeDataModel):
                  PortType.output: 3,
                  }
 
-    def model(self):
-        return 'MyDataModel'
-
     def data_type(self, port_type, port_index):
         return MyNodeData.data_type
 
-    def out_data(self, data):
+    def out_data(self, port):
         return MyNodeData()
 
     def set_in_data(self, node_data, port):

--- a/qtpynodeeditor/style.py
+++ b/qtpynodeeditor/style.py
@@ -174,11 +174,10 @@ class ConnectionStyle(Style):
         if type_id is None:
             return self.normal_color
 
-        hash = id(type_id)
         hue_range = 0xFF
-        random.seed(hash)
+        random.seed(type_id)
         hue = random.randint(0, hue_range)
-        sat = 120 + hash % 129
+        sat = 120 + id(type_id) % 129
         return QColor.fromHsl(hue, sat, 160)
 
 

--- a/qtpynodeeditor/style.py
+++ b/qtpynodeeditor/style.py
@@ -171,20 +171,12 @@ class ConnectionStyle(Style):
         -------
         value : QColor
         """
-        # TODO verify
-        #   std::size_t hash = qHash(type_id);
-        #   std::size_t const hue_range = 0xFF;
-        #   qsrand(hash);
-        #   std::size_t hue = qrand() % hue_range;
-        #   std::size_t sat = 120 + hash % 129;
-        #   return QColor::fromHsl(hue, sat, 160);
-        # }
         if type_id is None:
             return self.normal_color
 
         hash = id(type_id)
         hue_range = 0xFF
-
+        random.seed(hash)
         hue = random.randint(0, hue_range)
         sat = 120 + hash % 129
         return QColor.fromHsl(hue, sat, 160)

--- a/qtpynodeeditor/tests/test_basic.py
+++ b/qtpynodeeditor/tests/test_basic.py
@@ -23,7 +23,7 @@ class BasicDataModel(nodeeditor.NodeDataModel):
     def data_type(self, port_type, port_index):
         return MyNodeData.data_type
 
-    def out_data(self, data):
+    def out_data(self, port_index):
         return MyNodeData()
 
     def set_in_data(self, node_data, port):

--- a/qtpynodeeditor/tests/test_examples.py
+++ b/qtpynodeeditor/tests/test_examples.py
@@ -3,7 +3,7 @@ from qtpynodeeditor import examples
 
 
 @pytest.fixture(scope='function',
-                params=['style', 'calculator'])
+                params=['style', 'calculator', 'connection_colors'])
 def example(qtbot, qapp, request):
     example_module = getattr(examples, request.param)
     scene, view, nodes = example_module.main(qapp)


### PR DESCRIPTION
* Add connection colors example, which colors connections based on the indicated data types:

![image](https://user-images.githubusercontent.com/5139267/54888188-1fda4e80-4e58-11e9-8840-5fdd8c0bd6b5.png)

* Clean up a couple examples (unnecessary method / wrong arg name)