### PR TITLE
FIX: PySide2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,6 @@ matrix:
     - python: 3.7
       env:
         - QT_API=PySide2
-  allow_failures:
-  - python: 3.6
-    env:
-      - QT_API=PySide2
-  - python: 3.7
-    env:
-      - QT_API=PySide2
 
 install:
   # Install and configure miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,28 +41,8 @@ matrix:
         - QT_API=PySide2
 
 install:
-  # Install and configure miniconda
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-
-  # Ensure all packages are up-to-date
-  - conda update -q conda
-  - conda install conda-build anaconda-client
-  - conda config --append channels conda-forge
-  - conda info -a
-
-  # Build the conda recipe for this package
-  - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
-  - conda config --add channels "file://`pwd`/bld-dir"
-
-  # Create the test environment
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION qtpynodeeditor --file requirements.txt
-  - source deactivate
-  - source activate test-environment
-
+  # Install requirements
+  - pip install -Ur requirements.txt
   # Install additional development requirements
   - pip install -Ur dev-requirements.txt
   # Install the package
@@ -99,9 +79,33 @@ after_success:
   - codecov
 
   - |
-    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && "$CONDA_UPLOAD" == "1" ]]; then
-      if [[ $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' ]]; then
-        export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
-        anaconda upload bld-dir/linux-64/*.tar.bz2
+    if [[ "$CONDA_UPLOAD" == "1" ]]; then
+        # Install and configure miniconda
+        wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+        bash miniconda.sh -b -p $HOME/miniconda
+        export PATH="$HOME/miniconda/bin:$PATH"
+        hash -r
+        conda config --set always_yes yes --set changeps1 no
+
+        # Ensure all packages are up-to-date
+        conda update -q conda
+        conda install conda-build anaconda-client
+        conda config --append channels conda-forge
+        conda info -a
+
+        # Build the conda recipe for this package
+        conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
+        conda config --add channels "file://`pwd`/bld-dir"
+
+        # Create the test environment
+        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION qtpynodeeditor --file requirements.txt
+        source deactivate
+        source activate test-environment
+
+      if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO ]]; then
+        if [[ $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' ]]; then
+          export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
+          anaconda upload bld-dir/linux-64/*.tar.bz2
+        fi
       fi
     fi

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -2,7 +2,6 @@ import contextlib
 import json
 import os
 
-import qtpy
 from qtpy.QtCore import QDir, QObject, QPoint, QPointF, Qt, Signal
 from qtpy.QtWidgets import QFileDialog, QGraphicsScene
 

--- a/qtpynodeeditor/flow_view.py
+++ b/qtpynodeeditor/flow_view.py
@@ -3,7 +3,7 @@ import math
 
 from qtpy.QtCore import QLineF, QPoint, QRectF, Qt
 from qtpy.QtGui import (QContextMenuEvent, QKeyEvent, QMouseEvent, QPainter,
-                        QPen, QShowEvent, QWheelEvent)
+                        QPen, QShowEvent, QWheelEvent, QKeySequence)
 from qtpy.QtWidgets import (QAction, QGraphicsView, QLineEdit, QMenu,
                             QTreeWidget, QTreeWidgetItem, QWidgetAction)
 
@@ -75,14 +75,14 @@ class FlowView(QGraphicsView):
         # setup actions
         del self._clear_selection_action
         self._clear_selection_action = QAction("Clear Selection", self)
-        self._clear_selection_action.setShortcut(Qt.Key_Escape)
+        self._clear_selection_action.setShortcut(QKeySequence.Cancel)
         self._clear_selection_action.triggered.connect(self._scene.clearSelection)
 
         self.addAction(self._clear_selection_action)
         del self._delete_selection_action
         self._delete_selection_action = QAction("Delete Selection", self)
-        self._delete_selection_action.setShortcut(Qt.Key_Delete)
-        self._delete_selection_action.setShortcut(Qt.Key_Backspace)
+        self._delete_selection_action.setShortcut(QKeySequence.Backspace)
+        self._delete_selection_action.setShortcut(QKeySequence.Delete)
         self._delete_selection_action.triggered.connect(self.delete_selected)
         self.addAction(self._delete_selection_action)
 

--- a/qtpynodeeditor/node.py
+++ b/qtpynodeeditor/node.py
@@ -1,6 +1,6 @@
 import uuid
 
-from qtpy.QtCore import Property, QObject, QPointF, QSizeF
+from qtpy.QtCore import QObject, QPointF, QSizeF
 
 from .base import NodeBase, Serializable
 from .enums import ReactToConnectionState
@@ -115,7 +115,7 @@ class Node(QObject, Serializable, NodeBase):
         self._state.set_reaction(ReactToConnectionState.not_reacting)
         self._graphics_obj.update()
 
-    @Property(NodeGraphicsObject)
+    @property
     def graphics_object(self) -> NodeGraphicsObject:
         """
         Node graphics object

--- a/qtpynodeeditor/node_graphics_object.py
+++ b/qtpynodeeditor/node_graphics_object.py
@@ -1,4 +1,6 @@
-from qtpy.QtCore import QPoint, QRectF, QSize, QSizeF, Qt, QVariant
+import typing
+
+from qtpy.QtCore import QPoint, QRectF, QSize, QSizeF, Qt
 from qtpy.QtGui import QCursor, QPainter
 from qtpy.QtWidgets import (QGraphicsDropShadowEffect, QGraphicsItem,
                             QGraphicsObject, QGraphicsProxyWidget,
@@ -128,18 +130,18 @@ class NodeGraphicsObject(QGraphicsObject):
                           connection_style=self._style.connection,
                           )
 
-    def itemChange(self, change: QGraphicsItem.GraphicsItemChange, value: QVariant) -> QVariant:
+    def itemChange(self, change: QGraphicsItem.GraphicsItemChange, value: typing.Any) -> typing.Any:
         """
         itemChange
 
         Parameters
         ----------
         change : QGraphicsItem.GraphicsItemChange
-        value : QVariant
+        value : any
 
         Returns
         -------
-        value : QVariant
+        value : any
         """
         if change == self.ItemPositionChange and self.scene():
             self.move_connections()


### PR DESCRIPTION
Along with PyQt5 as before, PySide2 from conda-forge is now passing successfully:

```
platform darwin -- Python 3.7.3, pytest-5.2.1, py-1.8.0, pluggy-0.13.0 -- /Users/klauer/mc/envs/pyside2/bin/python
cachedir: .pytest_cache
PySide2 5.13.1 -- Qt runtime 5.12.5 -- Qt compiled 5.12.5
```

Closes #19 