### PR TITLE
ENH: node_context_menu signal should emit screen pos as well

### DIFF
--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -378,7 +378,9 @@ class FlowScene(QGraphicsScene, FlowSceneModel, QObject):
     #  Node has been added to the scene.
     #  Connect to self signal if need a correct position of node.
     node_placed = Signal(Node)
-    node_context_menu = Signal(Node, QPointF)
+
+    # node_context_menu(node, scene_position, screen_position)
+    node_context_menu = Signal(Node, QPointF, QPoint)
     node_double_clicked = Signal(Node)
     node_hover_left = Signal(Node)
     node_hovered = Signal(Node, QPoint)

--- a/qtpynodeeditor/node_graphics_object.py
+++ b/qtpynodeeditor/node_graphics_object.py
@@ -320,8 +320,8 @@ class NodeGraphicsObject(QGraphicsObject):
         ----------
         event : QGraphicsSceneContextMenuEvent
         """
-        self._scene.node_context_menu.emit(self._node,
-                                           self.mapToScene(event.pos()))
+        self._scene.node_context_menu.emit(
+            self._node, event.scenePos(), event.screenPos())
 
     def embed_q_widget(self):
         geom = self._node.geometry


### PR DESCRIPTION
New slot signature: `node_context_menu(node, scene_pos, screen_pos)`

This differs with the upstream library, but perhaps should be proposed there as well.