### PR TITLE
Fix dialog patterns and save caption

### DIFF
--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -93,7 +93,7 @@ class _FlowSceneModel:
     def save(self, file_name=None):
         if file_name is None:
             file_name, _ = QFileDialog.getSaveFileName(
-                None, "Open Flow Scene", QDir.homePath(),
+                None, "Save Flow Scene", QDir.homePath(),
                 "Flow Scene Files (*.flow)")
 
         if file_name:

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -94,7 +94,7 @@ class _FlowSceneModel:
         if file_name is None:
             file_name, _ = QFileDialog.getSaveFileName(
                 None, "Open Flow Scene", QDir.homePath(),
-                "Flow Scene Files (.flow)")
+                "Flow Scene Files (*.flow)")
 
         if file_name:
             file_name = str(file_name)
@@ -108,7 +108,7 @@ class _FlowSceneModel:
         if file_name is None:
             file_name, _ = QFileDialog.getOpenFileName(
                 None, "Open Flow Scene", QDir.homePath(),
-                "Flow Scene Files (.flow)")
+                "Flow Scene Files (*.flow)")
 
         if not os.path.exists(file_name):
             return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

- Change .flow to *.flow in the dialog filters so that the matching files are displayed.
- Change caption of the save dialog to "Save..."
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the open/save dialogs don't show the .flow files and have the same caption.

