### PR TITLE
FIX: FlowScene class hierarchy/init causes signals to fire twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
   include:
     - python: 3.6
       env:
+        - CHECK_STYLE=1
+    - python: 3.6
+      env:
         - CONDA_UPLOAD=1
         - BUILD_DOCS=1
         - QT_API=pyqt5
@@ -41,6 +44,15 @@ matrix:
         - QT_API=PySide2
 
 install:
+  - |
+    if [[ "$CHECK_STYLE" == "1" ]]; then
+      echo "Checking style with flake8..."
+      pip install flake8
+      flake8 qtpynodeeditor
+      FLAKE8_EXIT=$?
+      echo "flake8 exited with code $FLAKE8_EXIT"
+      exit $FLAKE8_EXIT
+    fi
   # Install requirements
   - pip install -Ur requirements.txt
   # Install additional development requirements
@@ -50,15 +62,12 @@ install:
   # Install the specific binding we're testing against
   - pip install "${QT_API}"
 
-
 before_script:
   # Run the window manager
   - "herbstluftwm &"
   - sleep 1
 
-
 script:
-  - flake8 qtpynodeeditor
   - export PYTEST_QT_API="${QT_API}"
   - coverage run run_tests.py
   - set -e

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -2,8 +2,7 @@ import contextlib
 import json
 import os
 
-import qtpy
-from qtpy.QtCore import QDir, QObject, QPoint, QPointF, Qt, Signal
+from qtpy.QtCore import QDir, QPoint, QPointF, Qt, Signal
 from qtpy.QtWidgets import QFileDialog, QGraphicsScene
 
 from . import style as style_module

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -44,7 +44,6 @@ class FlowSceneModel:
 
     def __init__(self, registry=None, **kwargs):
         super().__init__(**kwargs)
-        print('model init called')
         self._connections = []
         self._nodes = {}
 
@@ -184,7 +183,6 @@ class FlowSceneModel:
         ----------
         conn : Connection
         """
-        print('setup conn signals', conn)
         conn.connection_made_incomplete.connect(
             self.connection_deleted.emit, Qt.UniqueConnection)
 

--- a/qtpynodeeditor/tests/test_basic.py
+++ b/qtpynodeeditor/tests/test_basic.py
@@ -1,8 +1,11 @@
+import unittest.mock
+
 import pytest
 import qtpy.QtCore
 
 import qtpynodeeditor as nodeeditor
 from qtpynodeeditor import PortType
+
 
 
 class MyNodeData(nodeeditor.NodeData):
@@ -256,3 +259,36 @@ def test_smoke_repr(scene, view, model):
     conn = scene.create_connection(*ports)
     print()
     print('connection', conn)
+
+
+def test_smoke_scene_signal_connections(scene, view, model):
+    mock = unittest.mock.Mock()
+    scene.connection_created.connect(mock)
+
+    node1 = scene.create_node(model)
+    node2 = scene.create_node(model)
+    conn = scene.create_connection(node2[PortType.output][2],
+                                   node1[PortType.input][1])
+    assert mock.call_count == 1
+
+    mock = unittest.mock.Mock()
+    scene.connection_deleted.connect(mock)
+
+    node1 = scene.create_node(model)
+    node2 = scene.create_node(model)
+    scene.delete_connection(conn)
+    assert mock.call_count == 1
+
+
+def test_smoke_scene_signal_nodes(scene, view, model):
+    mock = unittest.mock.Mock()
+    scene.node_created.connect(mock)
+    node1 = scene.create_node(model)
+    node2 = scene.create_node(model)
+    assert mock.call_count == 2
+
+    mock = unittest.mock.Mock()
+    scene.node_deleted.connect(mock)
+    scene.remove_node(node1)
+    scene.remove_node(node2)
+    assert mock.call_count == 2

--- a/qtpynodeeditor/tests/test_basic.py
+++ b/qtpynodeeditor/tests/test_basic.py
@@ -7,7 +7,6 @@ import qtpynodeeditor as nodeeditor
 from qtpynodeeditor import PortType
 
 
-
 class MyNodeData(nodeeditor.NodeData):
     data_type = nodeeditor.NodeDataType('MyNodeData', 'My Node Data')
 


### PR DESCRIPTION
Closes #27 

Dealing with PyQt5 and PySide2 can be confusing at times - PySide2 doesn't support cooperative `__init__`. Looks like I picked the wrong fix the first go-around.

There will likely be more tweaks to this in the future, though my guess is no one is using the model outside of `FlowScene` for now.