### PR TITLE
MNT: remove __del__

### DIFF
--- a/qtpynodeeditor/connection.py
+++ b/qtpynodeeditor/connection.py
@@ -85,12 +85,6 @@ class Connection(QObject, Serializable, ConnectionBase):
             self._graphics_object._cleanup()
             self._graphics_object = None
 
-    def __del__(self):
-        try:
-            self._cleanup()
-        except Exception:
-            ...
-
     @property
     def style(self) -> StyleCollection:
         return self._style

--- a/qtpynodeeditor/connection_graphics_object.py
+++ b/qtpynodeeditor/connection_graphics_object.py
@@ -43,12 +43,6 @@ class ConnectionGraphicsObject(QGraphicsObject):
             self._scene.removeItem(self)
             self._scene = None
 
-    def __del__(self):
-        try:
-            self._cleanup()
-        except Exception:
-            ...
-
     @property
     def connection(self) -> ConnectionBase:
         """

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -427,12 +427,6 @@ class FlowScene(QGraphicsScene, _FlowSceneModel):
     def _cleanup(self):
         self.clear_scene()
 
-    def __del__(self):
-        try:
-            self._cleanup()
-        except Exception:
-            ...
-
     @property
     def allow_node_creation(self):
         return self._allow_node_creation

--- a/qtpynodeeditor/node.py
+++ b/qtpynodeeditor/node.py
@@ -43,12 +43,6 @@ class Node(QObject, Serializable, NodeBase):
             self._graphics_obj = None
             self._geometry = None
 
-    def __del__(self):
-        try:
-            self._cleanup()
-        except Exception:
-            ...
-
     def __getstate__(self) -> dict:
         """
         Save

--- a/qtpynodeeditor/node_graphics_object.py
+++ b/qtpynodeeditor/node_graphics_object.py
@@ -58,12 +58,6 @@ class NodeGraphicsObject(QGraphicsObject):
             self._scene.removeItem(self)
             self._scene = None
 
-    def __del__(self):
-        try:
-            self._cleanup()
-        except Exception:
-            ...
-
     def setPos(self, pos):
         super().setPos(pos)
         self.move_connections()


### PR DESCRIPTION
These are unnecessary at best, and cause crashes at teardown at worst. For example:

```
========================================================= 37 passed in 3.24s =========================================================
Fatal Python error: Segmentation fault

Current thread 0x0000000114be0dc0 (most recent call first):
  File "/Users/klauer/docs/Repos/qtpynodeeditor/qtpynodeeditor/connection_graphics_object.py", line 43 in _cleanup
  File "/Users/klauer/docs/Repos/qtpynodeeditor/qtpynodeeditor/connection.py", line 85 in _cleanup
  File "/Users/klauer/docs/Repos/qtpynodeeditor/qtpynodeeditor/connection.py", line 90 in __del__
Segmentation fault: 11
```