### PR TITLE
FIX: QFontMetrics.width() deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ install:
       echo "flake8 exited with code $FLAKE8_EXIT"
       exit $FLAKE8_EXIT
     fi
+  # Ensure pip is up-to-date
+  - pip install --upgrade pip
   # Install requirements
   - pip install -Ur requirements.txt
   # Install additional development requirements

--- a/qtpynodeeditor/node_geometry.py
+++ b/qtpynodeeditor/node_geometry.py
@@ -491,7 +491,8 @@ class NodeGeometry:
         if not names:
             return 0
 
-        return max(self._font_metrics.width(name) for name in names)
+        return max(self._font_metrics.horizontalAdvance(name)
+                   for name in names)
 
     @property
     def size(self):


### PR DESCRIPTION
Closes #33 

Did a quick comparison between the alternates `QFontMetrics.horizontalAdvance(str)` vs `QFontMetrics.boundingRect(str).width()` and didn't find much of a difference at least in the example case:

![image](https://user-images.githubusercontent.com/5139267/78611079-01ed4b00-781b-11ea-8f20-cd24677a3b13.png)
![image](https://user-images.githubusercontent.com/5139267/78611089-06b1ff00-781b-11ea-8b5c-52e661eb291f.png)
