### PR TITLE
FIX: check for cycles created by new connections

### DIFF
--- a/qtpynodeeditor/__init__.py
+++ b/qtpynodeeditor/__init__.py
@@ -4,7 +4,8 @@ from .connection_graphics_object import ConnectionGraphicsObject
 from .connection_painter import ConnectionPainter
 from .data_model_registry import DataModelRegistry
 from .enums import ConnectionPolicy, NodeValidationState, PortType
-from .exceptions import (ConnectionPointFailure, ConnectionPortNotEmptyFailure,
+from .exceptions import (ConnectionCycleFailure, ConnectionPointFailure,
+                         ConnectionPortNotEmptyFailure,
                          ConnectionRequiresPortFailure, ConnectionSelfFailure,
                          NodeConnectionFailure)
 from .flow_scene import FlowScene
@@ -22,6 +23,7 @@ from .style import (ConnectionStyle, FlowViewStyle, NodeStyle, Style,
 
 __all__ = [
     'Connection',
+    'ConnectionCycleFailure',
     'ConnectionGeometry',
     'ConnectionGraphicsObject',
     'ConnectionPainter',

--- a/qtpynodeeditor/connection.py
+++ b/qtpynodeeditor/connection.py
@@ -362,9 +362,12 @@ class Connection(QObject, Serializable, ConnectionBase):
         return self._ports[PortType.input].node
 
     @property
-    def output(self) -> Node:
+    def output_node(self) -> Node:
         'Output node'
         return self._ports[PortType.output].node
+
+    # For backward-compatibility:
+    output = output_node
 
     def propagate_empty_data(self):
         self.propagate_data(None)

--- a/qtpynodeeditor/exceptions.py
+++ b/qtpynodeeditor/exceptions.py
@@ -22,6 +22,11 @@ class ConnectionPortNotEmptyFailure(NodeConnectionFailure):
     ...
 
 
+class ConnectionCycleFailure(NodeConnectionFailure):
+    'Connection would introduce a cycle in the graph'
+    ...
+
+
 class PortsOfSameTypeError(NodeConnectionFailure):
     ...
 

--- a/qtpynodeeditor/node.py
+++ b/qtpynodeeditor/node.py
@@ -34,6 +34,9 @@ class Node(QObject, Serializable, NodeBase):
         self._model.data_updated.connect(self._on_port_index_data_updated)
         self._model.embedded_widget_size_updated.connect(self.on_node_size_updated)
 
+    def __hash__(self):
+        return id(self._uid)
+
     def __eq__(self, node):
         try:
             return node.id == self.id and self.model is node.model

--- a/qtpynodeeditor/node.py
+++ b/qtpynodeeditor/node.py
@@ -34,6 +34,12 @@ class Node(QObject, Serializable, NodeBase):
         self._model.data_updated.connect(self._on_port_index_data_updated)
         self._model.embedded_widget_size_updated.connect(self.on_node_size_updated)
 
+    def __eq__(self, node):
+        try:
+            return node.id == self.id and self.model is node.model
+        except AttributeError:
+            return False
+
     def __getitem__(self, key):
         return self._state[key]
 

--- a/qtpynodeeditor/node_state.py
+++ b/qtpynodeeditor/node_state.py
@@ -49,12 +49,27 @@ class NodeState:
         yield from self[PortType.output].values()
 
     @property
+    def output_connections(self):
+        """All output connections"""
+        return [
+            connection
+            for idx, port in self._ports[PortType.output].items()
+            for connection in port.connections
+        ]
+
+    @property
+    def input_connections(self):
+        """All input connections"""
+        return [
+            connection
+            for idx, port in self._ports[PortType.input].items()
+            for connection in port.connections
+        ]
+
+    @property
     def all_connections(self):
-        return [connection
-                for port_type, ports in self._ports.items()
-                for idx, port in ports.items()
-                for connection in port.connections
-                ]
+        """All input and output connections"""
+        return self.input_connections + self.output_connections
 
     def connections(self, port_type: PortType, port_index: int) -> list:
         """

--- a/qtpynodeeditor/tests/test_basic.py
+++ b/qtpynodeeditor/tests/test_basic.py
@@ -177,6 +177,31 @@ def test_smoke_node_size_updated(scene, view, model):
     view.update()
 
 
+def test_connection_cycles(scene, view, model):
+    node1 = scene.create_node(model)
+    node2 = scene.create_node(model)
+    node3 = scene.create_node(model)
+    scene.create_connection(node1[PortType.output][0],
+                            node2[PortType.input][0])
+    scene.create_connection(node2[PortType.output][0],
+                            node3[PortType.input][0])
+
+    # node1 -> node2 -> node3
+
+    # Test with a fully-specified connection: try to connect node3->node1
+    with pytest.raises(nodeeditor.ConnectionCycleFailure):
+        scene.create_connection(node3[PortType.output][0],
+                                node1[PortType.input][0])
+
+    # Test with a half-specified connection: start with node3
+    conn = scene.create_connection(node3[PortType.output][0])
+    # and then pretend the user attempts to connect it to node1:
+    interaction = nodeeditor.NodeConnectionInteraction(
+        node=node1, connection=conn, scene=scene)
+
+    assert interaction.creates_cycle
+
+
 def test_smoke_connection_interaction(scene, view, model):
     node1 = scene.create_node(model)
     node2 = scene.create_node(model)


### PR DESCRIPTION
Closes #35 

Checks cycles in `scene.create_connection` (i.e., for code mistakenly creating cycles) and also when the user completes a connection.

Adds exception type `ConnectionCycleFailure`

Adds some API niceties:
* `Node` is hashed by uid (now usable in sets/dicts/etc)
* Adds `Node.has_any_connection`, e.g., does `node1` have `node2` anywhere upstream or downstream of it in the pipeline?
* Adds `Node.has_connection_by_port_type` e.g., does `node1` have `node2` anywhere downstream of it in the pipeline?
* Adds`Node.walk_paths_by_port_type` to walk through upstream/downstream nodes. For example, if you have `node1 -> node2 -> node3` and request to walk output paths from `node1`, it would yield `(node1, node2)` and `(node1, node2, node3)`. This is used internally for the above two methods.
* Adds `NodeState.output_connections`, `NodeState.input_connections` to go along with `.all_connections`