### PR TITLE
Interaction check data type compatibility

### DIFF
--- a/qtpynodeeditor/__init__.py
+++ b/qtpynodeeditor/__init__.py
@@ -7,7 +7,7 @@ from .enums import ConnectionPolicy, NodeValidationState, PortType
 from .exceptions import (ConnectionCycleFailure, ConnectionPointFailure,
                          ConnectionPortNotEmptyFailure,
                          ConnectionRequiresPortFailure, ConnectionSelfFailure,
-                         NodeConnectionFailure)
+                         ConnectionDataTypeFailure, NodeConnectionFailure)
 from .flow_scene import FlowScene
 from .flow_view import FlowView
 from .node import Node, NodeDataType
@@ -33,6 +33,7 @@ __all__ = [
     'ConnectionSelfFailure',
     'ConnectionPointFailure',
     'ConnectionPortNotEmptyFailure',
+    'ConnectionDataTypeFailure',
     'DataModelRegistry',
     'FlowScene',
     'FlowView',

--- a/qtpynodeeditor/connection.py
+++ b/qtpynodeeditor/connection.py
@@ -351,7 +351,7 @@ class Connection(QObject, Serializable, ConnectionBase):
         if not in_port:
             return
 
-        if self._converter:
+        if node_data is not None and self._converter:
             node_data = self._converter(node_data)
 
         in_port.node.propagate_data(node_data, in_port)

--- a/qtpynodeeditor/examples/calculator.py
+++ b/qtpynodeeditor/examples/calculator.py
@@ -6,6 +6,7 @@ from qtpy.QtGui import QDoubleValidator
 from qtpy.QtWidgets import QApplication, QLabel, QLineEdit, QWidget
 
 import qtpynodeeditor as nodeeditor
+from qtpynodeeditor.type_converter import TypeConverter
 from qtpynodeeditor import (NodeData, NodeDataModel, NodeDataType,
                             NodeValidationState, Port, PortType)
 
@@ -372,10 +373,10 @@ def main(app):
         registry.register_model(model, category='Operations',
                                 style=None)
 
-    registry.register_type_converter(DecimalData, IntegerData,
-                                     decimal_to_integer_converter)
-    registry.register_type_converter(IntegerData, DecimalData,
-                                     decimal_to_integer_converter)
+    dec_converter = TypeConverter(DecimalData.data_type, IntegerData.data_type, decimal_to_integer_converter)
+    int_converter = TypeConverter(IntegerData.data_type, DecimalData.data_type, integer_to_decimal_converter)
+    registry.register_type_converter(DecimalData.data_type, IntegerData.data_type, dec_converter)
+    registry.register_type_converter(IntegerData.data_type, DecimalData.data_type, int_converter)
 
     scene = nodeeditor.FlowScene(registry=registry)
 

--- a/qtpynodeeditor/examples/calculator.py
+++ b/qtpynodeeditor/examples/calculator.py
@@ -44,6 +44,7 @@ class IntegerData(NodeData):
     def lock(self):
         return self._lock
 
+    @property
     def number(self) -> int:
         'The number data'
         return self._number

--- a/qtpynodeeditor/exceptions.py
+++ b/qtpynodeeditor/exceptions.py
@@ -27,6 +27,11 @@ class ConnectionCycleFailure(NodeConnectionFailure):
     ...
 
 
+class ConnectionDataTypeFailure(NodeConnectionFailure):
+    'Ports do not have compatible data types'
+    ...
+
+
 class PortsOfSameTypeError(NodeConnectionFailure):
     ...
 

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -15,7 +15,7 @@ from .node import Node
 from .node_data import NodeDataModel, NodeDataType
 from .node_graphics_object import NodeGraphicsObject
 from .port import Port, PortType
-from .type_converter import DefaultTypeConverter, TypeConverter
+from .type_converter import TypeConverter
 
 
 def locate_node_at(scene_point, scene, view_transform):
@@ -477,9 +477,8 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
                     # If not specified, try to get it from the registry
                     converter = self.registry.get_type_converter(out_port.data_type,
                                                                  in_port.data_type)
-                if (not converter or converter == DefaultTypeConverter
-                        or (converter.type_in != out_port.data_type
-                            or converter.type_out != in_port.data_type)):
+                if (not converter or (converter.type_in != out_port.data_type
+                                      or converter.type_out != in_port.data_type)):
                     raise ConnectionDataTypeFailure(
                         f'{in_port.data_type} and {out_port.data_type} are not compatible'
                     )
@@ -564,7 +563,7 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
         def get_converter():
             converter = connection_json.get("converter", None)
             if converter is None:
-                return DefaultTypeConverter
+                return None
 
             in_type = NodeDataType(
                 id=converter["in"]["id"],

--- a/qtpynodeeditor/node_connection_interaction.py
+++ b/qtpynodeeditor/node_connection_interaction.py
@@ -8,7 +8,6 @@ from .exceptions import (ConnectionCycleFailure, ConnectionPointFailure,
                          ConnectionRequiresPortFailure, ConnectionSelfFailure,
                          ConnectionDataTypeFailure, NodeConnectionFailure)
 from .port import PortType, opposite_port
-from .type_converter import DefaultTypeConverter
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +100,7 @@ class NodeConnectionInteraction:
 
         candidate_node_data_type = port.data_type
         if connection_data_type.id == candidate_node_data_type.id:
-            return port, DefaultTypeConverter
+            return port, None
 
         registry = self._scene.registry
         if required_port == PortType.input:

--- a/qtpynodeeditor/node_connection_interaction.py
+++ b/qtpynodeeditor/node_connection_interaction.py
@@ -6,7 +6,7 @@ from .base import ConnectionBase, FlowSceneBase, NodeBase
 from .exceptions import (ConnectionCycleFailure, ConnectionPointFailure,
                          ConnectionPortNotEmptyFailure,
                          ConnectionRequiresPortFailure, ConnectionSelfFailure,
-                         NodeConnectionFailure)
+                         ConnectionDataTypeFailure, NodeConnectionFailure)
 from .port import PortType, opposite_port
 from .type_converter import DefaultTypeConverter
 
@@ -59,6 +59,8 @@ class NodeConnectionInteraction:
         Raises
         ------
         NodeConnectionFailure
+        ConnectionDataTypeFailure
+            If port data types are not compatible
         """
         # 1) Connection requires a port
         required_port = self.connection_required_port
@@ -108,6 +110,11 @@ class NodeConnectionInteraction:
         else:
             converter = registry.get_type_converter(candidate_node_data_type,
                                                     connection_data_type)
+        if not converter:
+            raise ConnectionDataTypeFailure(
+                f'{connection_data_type} and {candidate_node_data_type} are not compatible'
+            )
+
         return port, converter
 
     def try_connect(self) -> bool:

--- a/qtpynodeeditor/tests/test_basic.py
+++ b/qtpynodeeditor/tests/test_basic.py
@@ -176,6 +176,18 @@ def test_clear_scene(scene, view, model):
     assert len(all_c2) == 0
 
 
+def test_get_and_set_state(scene, model):
+    node1 = scene.create_node(model)
+    node2 = scene.create_node(model)
+    scene.create_connection(node2[PortType.output][2],
+                            node1[PortType.input][1],
+                            )
+    state = scene.__getstate__()
+    scene.__setstate__(state)
+
+    assert scene.__getstate__() == state
+
+
 def test_save_load(tmp_path, scene, view, model):
     node1 = scene.create_node(model)
     node2 = scene.create_node(model)

--- a/qtpynodeeditor/tests/test_basic.py
+++ b/qtpynodeeditor/tests/test_basic.py
@@ -135,6 +135,30 @@ def test_create_connection(scene, view, model):
     assert len(all_c2) == 0
 
 
+def test_create_connection_with_converter(scene, view, model, other_model):
+    node1 = scene.create_node(model)
+    node2 = scene.create_node(other_model)
+
+    # Converter not registerd, must raise Exception
+    with pytest.raises(nodeeditor.ConnectionDataTypeFailure):
+        scene.create_connection(node1[PortType.output][0], node2[PortType.input][0])
+
+    # Wrong converter, must fail
+    converter = nodeeditor.type_converter.TypeConverter(MyOtherNodeData.data_type,
+                                                        MyNodeData.data_type,
+                                                        lambda x: None)
+    scene.registry.register_type_converter(MyNodeData.data_type, MyOtherNodeData.data_type, converter)
+    with pytest.raises(nodeeditor.ConnectionDataTypeFailure):
+        scene.create_connection(node1[PortType.output][0], node2[PortType.input][0])
+
+    # Correct converter registered, must pass
+    converter = nodeeditor.type_converter.TypeConverter(MyNodeData.data_type,
+                                                        MyOtherNodeData.data_type,
+                                                        lambda x: None)
+    scene.registry.register_type_converter(MyNodeData.data_type, MyOtherNodeData.data_type, converter)
+    scene.create_connection(node1[PortType.output][0], node2[PortType.input][0])
+
+
 def test_clear_scene(scene, view, model):
     node1 = scene.create_node(model)
     node2 = scene.create_node(model)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add data type checks in `FlowScene.create_connection` and `NodeConnectionInteraction.can_connect`
<!--- Describe your changes in detail -->

## Motivation and Context
Currently it's possible to connect two nodes with incompatible data types, this PR tries to remedy this.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Added tests `test_create_connection_with_converter` and `test_connection_interaction_wrong_data_type`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
Docstrings and inline comments.
