### PR TITLE
FIX: accidentally creating NodeDataModel twice

### DIFF
--- a/qtpynodeeditor/data_model_registry.py
+++ b/qtpynodeeditor/data_model_registry.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 
 from .node_data import NodeDataModel, NodeDataType
 from .type_converter import TypeConverter
@@ -39,7 +40,7 @@ class DataModelRegistry:
 
     def create(self, model_name: str) -> NodeDataModel:
         """
-        Create
+        Create a :class:`NodeDataModel` given its user-friendly name.
 
         Parameters
         ----------
@@ -47,10 +48,44 @@ class DataModelRegistry:
 
         Returns
         -------
-        value : (NodeDataModel, init_kwargs)
+        data_model_instance : NodeDataModel
+            The instance of the given data model.
+
+        Raises
+        ------
+        ValueError
+            If the model name is not registered.
         """
-        cls, kwargs = self._item_creators[model_name]
+        cls, kwargs = self.get_model_by_name(model_name)
         return cls(**kwargs)
+
+    def get_model_by_name(self, model_name: str
+                          ) -> typing.Tuple[typing.Type[NodeDataModel], dict]:
+        """
+        Get information on how to create a specific :class:`NodeDataModel`
+        node given its user-friendly name.
+
+        Parameters
+        ----------
+        model_name : str
+
+        Returns
+        -------
+        data_model : NodeDataModel
+            The data model class.
+
+        init_kwargs : dict
+            Default init keyword arguments.
+
+        Raises
+        ------
+        ValueError
+            If the model name is not registered.
+        """
+        try:
+            return self._item_creators[model_name]
+        except KeyError:
+            raise ValueError(f'Unknown model: {model_name}') from None
 
     def registered_model_creators(self) -> dict:
         """

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -329,10 +329,6 @@ class FlowSceneModel:
     def _new_node_context(self, data_model_name, *, emit_placed=False):
         'Context manager: creates Node/yields it, handling necessary Signals'
         data_model = self._registry.create(data_model_name)
-        if not data_model:
-            raise ValueError("No registered model with name {}"
-                             "".format(data_model_name))
-
         node = Node(data_model)
         yield node
         self._nodes[node.id] = node

--- a/qtpynodeeditor/flow_view.py
+++ b/qtpynodeeditor/flow_view.py
@@ -165,14 +165,15 @@ class FlowView(QGraphicsView):
             if model_name == skip_text:
                 return
 
-            type_ = self._scene.registry.create(model_name)
-            if type_:
-                node = self._scene.create_node(type_)
+            try:
+                model, _ = self._scene.registry.get_model_by_name(model_name)
+            except ValueError:
+                logger.error("Model not found: %s", model_name)
+            else:
+                node = self._scene.create_node(model)
                 pos_view = self.mapToScene(pos)
                 node.graphics_object.setPos(pos_view)
                 self._scene.node_placed.emit(node)
-            else:
-                logger.debug("Model not found")
 
             model_menu.close()
 

--- a/qtpynodeeditor/node_connection_interaction.py
+++ b/qtpynodeeditor/node_connection_interaction.py
@@ -63,7 +63,7 @@ class NodeConnectionInteraction:
         # 1) Connection requires a port
         required_port = self.connection_required_port
         if required_port == PortType.none:
-            raise ConnectionRequiresPortFailure(f'Connection requires a port')
+            raise ConnectionRequiresPortFailure('Connection requires a port')
         elif required_port not in (PortType.input, PortType.output):
             raise ValueError(f'Invalid port specified {required_port}')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The initial registry `.create()` apparently was supposed to return `(cls, kwargs)` but mistakenly was returning `cls(**kwargs)`, causing duplicate `NodeDataModel` instances.

This PR adds `get_model_by_name` which includes the intended original functionality, fixing the duplicate bug.

## Motivation and Context
Closes #42 

## How Has This Been Tested?
Test suite continues to work. (Note that continuous integration is broken at the moment)
Tested locally and saw that models are no longer created twice when created interactively (i.e., through the `FlowView` context menu `click_handler`).

cc @Picard2200 - mind giving this PR a try?