### PR TITLE
Property access fixes, miscellaneous cleanup, and some attempts to make mypy happier

### DIFF
--- a/qtpynodeeditor/base.py
+++ b/qtpynodeeditor/base.py
@@ -1,15 +1,3 @@
-class NodeBase:
-    ...
-
-
-class ConnectionBase:
-    ...
-
-
-class FlowSceneBase:
-    ...
-
-
 class Serializable:
     'Interface for a serializable class'
 

--- a/qtpynodeeditor/connection.py
+++ b/qtpynodeeditor/connection.py
@@ -3,7 +3,7 @@ import uuid
 from qtpy.QtCore import QObject, Signal
 
 from . import exceptions
-from .base import ConnectionBase, Serializable
+from .base import Serializable
 from .connection_geometry import ConnectionGeometry
 from .connection_graphics_object import ConnectionGraphicsObject
 from .node import Node, NodeDataType
@@ -13,7 +13,7 @@ from .style import StyleCollection
 from .type_converter import TypeConverter
 
 
-class Connection(QObject, Serializable, ConnectionBase):
+class Connection(QObject, Serializable):
     connection_completed = Signal(QObject)
     connection_made_incomplete = Signal(QObject)
     updated = Signal(QObject)

--- a/qtpynodeeditor/connection.py
+++ b/qtpynodeeditor/connection.py
@@ -1,3 +1,4 @@
+import typing
 import uuid
 
 from qtpy.QtCore import QObject, Signal
@@ -229,7 +230,7 @@ class Connection(QObject, Serializable):
         """
         return self._connection_geometry
 
-    def get_node(self, port_type: PortType) -> Node:
+    def get_node(self, port_type: PortType) -> typing.Optional[Node]:
         """
         Get node
 
@@ -242,8 +243,7 @@ class Connection(QObject, Serializable):
         value : Node
         """
         port = self._ports[port_type]
-        if port is not None:
-            return port.node
+        return port.node if port is not None else None
 
     @property
     def nodes(self):
@@ -314,13 +314,13 @@ class Connection(QObject, Serializable):
             return ports[valid_type].data_type
 
     @property
-    def type_converter(self) -> TypeConverter:
+    def type_converter(self) -> typing.Optional[TypeConverter]:
         """
-        Set type converter
+        The type converter used for the connection.
 
         Returns
         -------
-        converter : TypeConverter
+        converter : TypeConverter or None
         """
         return self._converter
 

--- a/qtpynodeeditor/connection_graphics_object.py
+++ b/qtpynodeeditor/connection_graphics_object.py
@@ -1,3 +1,5 @@
+import typing
+
 from qtpy.QtCore import QRectF
 from qtpy.QtGui import QPainter, QPainterPath
 from qtpy.QtWidgets import (QGraphicsBlurEffect, QGraphicsItem,
@@ -5,10 +7,13 @@ from qtpy.QtWidgets import (QGraphicsBlurEffect, QGraphicsItem,
                             QGraphicsSceneMouseEvent, QStyleOptionGraphicsItem,
                             QWidget)
 
-from .base import ConnectionBase
 from .connection_painter import ConnectionPainter
 from .node_connection_interaction import NodeConnectionInteraction
 from .port import PortType, opposite_port
+
+if typing.TYPE_CHECKING:
+    from .connection import Connection  # noqa
+
 
 debug_drawing = False
 
@@ -44,7 +49,7 @@ class ConnectionGraphicsObject(QGraphicsObject):
             self._scene = None
 
     @property
-    def connection(self) -> ConnectionBase:
+    def connection(self) -> 'Connection':
         """
         Connection
 

--- a/qtpynodeeditor/connection_painter.py
+++ b/qtpynodeeditor/connection_painter.py
@@ -1,10 +1,15 @@
+import typing
+
 from qtpy.QtCore import QLineF, QPoint, QSize, Qt
 from qtpy.QtGui import QIcon, QPainter, QPainterPath, QPainterPathStroker, QPen
 
-from .base import ConnectionBase
 from .connection_geometry import ConnectionGeometry
 from .enums import PortType
 from .style import ConnectionStyle
+
+if typing.TYPE_CHECKING:
+    from .connection import Connection  # noqa
+
 
 use_debug_drawing = False
 
@@ -164,7 +169,7 @@ def draw_normal_line(painter, connection, style):
 
 class ConnectionPainter:
     @staticmethod
-    def paint(painter: QPainter, connection: ConnectionBase,
+    def paint(painter: QPainter, connection: 'Connection',
               style: ConnectionStyle):
         """
         Paint

--- a/qtpynodeeditor/data_model_registry.py
+++ b/qtpynodeeditor/data_model_registry.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 
-from .node_data import NodeDataModel, NodeDataType
+from .node_data import NodeData, NodeDataModel, NodeDataType
 from .type_converter import TypeConverter
 
 logger = logging.getLogger(__name__)
@@ -20,21 +20,29 @@ class DataModelRegistry:
         self._categories.add(category)
         self._models_category[name] = category
 
-    def register_type_converter(self, type_in: NodeDataType, type_out:
-                                NodeDataType, type_converter: TypeConverter):
+    def register_type_converter(self,
+                                type_in: NodeDataType,
+                                type_out: NodeDataType,
+                                type_converter: TypeConverter):
         """
-        Register type converter
+        Register a type converter for a given data type.
 
         Parameters
         ----------
-        id_ : NodeData subclass or TypeConverterId
+        type_in : NodeDataType or NodeData subclass
+            The input type.
+
+        type_out : NodeDataType or NodeData subclass
+            The output type.
+
         type_converter : TypeConverter
+            The type converter to use for the conversion.
         """
         # TODO typing annotation
-        if hasattr(type_in, 'type'):
-            type_in = type_in.type
-        if hasattr(type_out, 'type'):
-            type_out = type_out.type
+        if hasattr(type_in, 'data_type'):
+            type_in = typing.cast(NodeData, type_in).data_type
+        if hasattr(type_out, 'data_type'):
+            type_out = typing.cast(NodeData, type_out).data_type
 
         self.type_converters[(type_in, type_out)] = type_converter
 

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -159,6 +159,19 @@ class FlowSceneModel:
         scene_json["connections"] = connection_json_array
         return scene_json
 
+    def restore_connection(self, connection_json: dict) -> Connection:
+        """
+        Restore a connection.  To be overridden in a subclass.
+
+        Parameters
+        ----------
+        connection_json : dict
+
+        Returns
+        -------
+        value : Connection
+        """
+
     def __setstate__(self, doc: dict):
         """
         Load scene state from a dictionary
@@ -538,7 +551,7 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
 
     def restore_connection(self, connection_json: dict) -> Connection:
         """
-        Restore connection
+        Restore a connection.
 
         Parameters
         ----------

--- a/qtpynodeeditor/node.py
+++ b/qtpynodeeditor/node.py
@@ -4,7 +4,7 @@ import uuid
 
 from qtpy.QtCore import QObject, QPointF, QSizeF
 
-from .base import NodeBase, Serializable
+from .base import Serializable
 from .enums import ReactToConnectionState
 from .node_data import NodeData, NodeDataModel, NodeDataType
 from .node_geometry import NodeGeometry
@@ -14,7 +14,7 @@ from .port import Port, PortType
 from .style import NodeStyle
 
 
-class Node(QObject, Serializable, NodeBase):
+class Node(QObject, Serializable):
     def __init__(self, data_model: NodeDataModel):
         '''
         A single Node in the scene

--- a/qtpynodeeditor/node.py
+++ b/qtpynodeeditor/node.py
@@ -1,6 +1,7 @@
 import collections
 import typing
 import uuid
+from typing import Optional
 
 from qtpy.QtCore import QObject, QPointF, QSizeF
 
@@ -15,6 +16,13 @@ from .style import NodeStyle
 
 
 class Node(QObject, Serializable):
+    _model: NodeDataModel
+    _uid: str
+    _style: NodeStyle
+    _state: NodeState
+    _geometry: NodeGeometry
+    _graphics_obj: Optional[NodeGraphicsObject]
+
     def __init__(self, data_model: NodeDataModel):
         '''
         A single Node in the scene
@@ -83,7 +91,8 @@ class Node(QObject, Serializable):
         )
 
     def walk_paths_by_port_type(
-            self, port_type: PortType) -> typing.Iterable['Node']:
+                self, port_type: PortType
+            ) -> typing.Generator[typing.Tuple['Node', ...], None, None]:
         """
         Yields paths to connected nodes by port type
 
@@ -92,6 +101,11 @@ class Node(QObject, Serializable):
         node_path : tuple
             The path to the node
         """
+        seen: typing.Set[typing.Union[Node, None]]
+        pending: typing.Deque[
+            typing.Tuple[typing.List[Node], Node]
+        ]
+
         seen = set([None])
         pending = collections.deque([([], self)])
 
@@ -134,6 +148,7 @@ class Node(QObject, Serializable):
         -------
         value : dict
         """
+        assert self._graphics_obj is not None
         return {
             "id": self._uid,
             "model": self._model.__getstate__(),
@@ -179,6 +194,9 @@ class Node(QObject, Serializable):
         node_data_type : NodeDataType
         scene_point : QPointF
         """
+        if self._graphics_obj is None:
+            return
+
         transform = self._graphics_obj.sceneTransform()
         inverted, invertible = transform.inverted()
         if invertible:
@@ -193,9 +211,9 @@ class Node(QObject, Serializable):
         self._graphics_obj.update()
 
     @property
-    def graphics_object(self) -> NodeGraphicsObject:
+    def graphics_object(self) -> Optional[NodeGraphicsObject]:
         """
-        Node graphics object
+        Get/set the associated node graphics object.
 
         Returns
         -------
@@ -205,20 +223,13 @@ class Node(QObject, Serializable):
 
     @graphics_object.setter
     def graphics_object(self, graphics: NodeGraphicsObject):
-        """
-        Set graphics object
-
-        Parameters
-        ----------
-        graphics : NodeGraphicsObject
-        """
         self._graphics_obj = graphics
         self._geometry.recalculate_size()
 
     @property
     def geometry(self) -> NodeGeometry:
         """
-        Node geometry
+        Get the node geometry.
 
         Returns
         -------
@@ -229,7 +240,7 @@ class Node(QObject, Serializable):
     @property
     def model(self) -> NodeDataModel:
         """
-        Node data model
+        Get the node data model.
 
         Returns
         -------
@@ -253,13 +264,14 @@ class Node(QObject, Serializable):
 
         self._model.set_in_data(node_data, input_port)
 
-        # Recalculate the nodes visuals. A data change can result in the node
-        # taking more space than before, so self forces a recalculate+repaint
-        # on the affected node
-        self._graphics_obj.set_geometry_changed()
-        self._geometry.recalculate_size()
-        self._graphics_obj.update()
-        self._graphics_obj.move_connections()
+        if self._graphics_obj is not None:
+            # Recalculate the nodes visuals. A data change can result in the
+            # node taking more space than before, so self forces a
+            # recalculate+repaint on the affected node
+            self._graphics_obj.set_geometry_changed()
+            self._geometry.recalculate_size()
+            self._graphics_obj.update()
+            self._graphics_obj.move_connections()
 
     def _on_port_index_data_updated(self, port_index: int):
         """
@@ -326,7 +338,8 @@ class Node(QObject, Serializable):
         -------
         value : QPointF
         """
-        return self._graphics_obj.pos()
+        if self._graphics_obj is not None:
+            return self._graphics_obj.pos()
 
     @position.setter
     def position(self, pos):

--- a/qtpynodeeditor/node_connection_interaction.py
+++ b/qtpynodeeditor/node_connection_interaction.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+from typing import Optional, Tuple
 
 from qtpy.QtCore import QPointF
 
@@ -8,11 +9,13 @@ from .exceptions import (ConnectionCycleFailure, ConnectionDataTypeFailure,
                          ConnectionRequiresPortFailure, ConnectionSelfFailure,
                          NodeConnectionFailure)
 from .port import PortType, opposite_port
+from .type_converter import TypeConverter
 
 if typing.TYPE_CHECKING:
     from .connection import Connection  # noqa
     from .flow_scene import FlowScene  # noqa
     from .node import Node  # noqa
+    from .port import Port  # noqa
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +46,7 @@ class NodeConnectionInteraction:
         return self.connection_node.has_connection_by_port_type(
             self._node, required_port)
 
-    def can_connect(self) -> bool:
+    def can_connect(self) -> Tuple['Port', Optional[TypeConverter]]:
         """
         Can connect when following conditions are met:
             1) Connection 'requires' a port - i.e., is missing either a start
@@ -60,8 +63,11 @@ class NodeConnectionInteraction:
 
         Returns
         -------
-        (port_index, converter) : (int, TypeConverter)
-            where port_index is the index of the port to be connected
+        port : Port
+            The port to be connected.
+
+        converter : TypeConverter
+            The data type converter to use.
 
         Raises
         ------
@@ -170,7 +176,7 @@ class NodeConnectionInteraction:
 
         return True
 
-    def disconnect(self, port_to_disconnect: PortType) -> bool:
+    def disconnect(self, port_to_disconnect: PortType):
         """
         1) Node and Connection should be already connected
         2) If so, clear Connection entry in the NodeState
@@ -180,10 +186,6 @@ class NodeConnectionInteraction:
         Parameters
         ----------
         port_to_disconnect : PortType
-
-        Returns
-        -------
-        value : bool
         """
         port_index = self._connection.get_port_index(port_to_disconnect)
         state = self._node.state
@@ -253,7 +255,7 @@ class NodeConnectionInteraction:
 
     def node_port_under_scene_point(self,
                                     port_type: PortType,
-                                    scene_point: QPointF) -> 'Node':
+                                    scene_point: QPointF) -> Optional['Port']:
         """
         Node port under scene point
 
@@ -264,7 +266,7 @@ class NodeConnectionInteraction:
 
         Returns
         -------
-        value : int
+        port : Port
         """
         node_geom = self._node.geometry
         scene_transform = self._node.graphics_object.sceneTransform()

--- a/qtpynodeeditor/node_connection_interaction.py
+++ b/qtpynodeeditor/node_connection_interaction.py
@@ -1,19 +1,27 @@
 import logging
+import typing
 
 from qtpy.QtCore import QPointF
 
-from .base import ConnectionBase, FlowSceneBase, NodeBase
-from .exceptions import (ConnectionCycleFailure, ConnectionPointFailure,
-                         ConnectionPortNotEmptyFailure,
+from .exceptions import (ConnectionCycleFailure, ConnectionDataTypeFailure,
+                         ConnectionPointFailure, ConnectionPortNotEmptyFailure,
                          ConnectionRequiresPortFailure, ConnectionSelfFailure,
-                         ConnectionDataTypeFailure, NodeConnectionFailure)
+                         NodeConnectionFailure)
 from .port import PortType, opposite_port
+
+if typing.TYPE_CHECKING:
+    from .connection import Connection  # noqa
+    from .flow_scene import FlowScene  # noqa
+    from .node import Node  # noqa
+
 
 logger = logging.getLogger(__name__)
 
 
 class NodeConnectionInteraction:
-    def __init__(self, node: NodeBase, connection: ConnectionBase, scene: FlowSceneBase):
+    def __init__(self, node: 'Node',
+                 connection: 'Connection',
+                 scene: 'FlowScene'):
         '''
         An interactive connection interaction to complete `connection` with the
         given node
@@ -243,7 +251,9 @@ class NodeConnectionInteraction:
         return port.get_mapped_scene_position(
             self._node.graphics_object.sceneTransform())
 
-    def node_port_under_scene_point(self, port_type: PortType, scene_point: QPointF) -> NodeBase:
+    def node_port_under_scene_point(self,
+                                    port_type: PortType,
+                                    scene_point: QPointF) -> 'Node':
         """
         Node port under scene point
 

--- a/qtpynodeeditor/node_data.py
+++ b/qtpynodeeditor/node_data.py
@@ -1,5 +1,6 @@
 import inspect
 from collections import namedtuple
+from typing import Optional
 
 from qtpy.QtCore import QObject, Signal
 from qtpy.QtWidgets import QWidget
@@ -42,8 +43,8 @@ class NodeData:
 
 
 class NodeDataModel(QObject, Serializable):
-    name = None
-    caption = None
+    name: Optional[str] = None
+    caption: Optional[str] = None
     caption_visible = True
     num_ports = {PortType.input: 1,
                  PortType.output: 1,

--- a/qtpynodeeditor/node_geometry.py
+++ b/qtpynodeeditor/node_geometry.py
@@ -1,16 +1,19 @@
 import math
+import typing
 
 from qtpy.QtCore import QPointF, QRect, QRectF, QSizeF
 from qtpy.QtGui import QFont, QFontMetrics, QTransform
 from qtpy.QtWidgets import QSizePolicy
 
-from .base import NodeBase
 from .enums import NodeValidationState, PortType
 from .port import Port
 
+if typing.TYPE_CHECKING:
+    from .node import Node  # noqa
+
 
 class NodeGeometry:
-    def __init__(self, node: NodeBase):
+    def __init__(self, node: 'Node'):
         super().__init__()
         self._node = node
         self._model = node.model
@@ -375,11 +378,11 @@ class NodeGeometry:
     def calculate_node_position_between_node_ports(
             target_port_index: int,
             target_port: PortType,
-            target_node: NodeBase,
+            target_node: 'Node',
             source_port_index: int,
             source_port: PortType,
-            source_node: NodeBase,
-            new_node: NodeBase) -> QPointF:
+            source_node: 'Node',
+            new_node: 'Node') -> QPointF:
         """
         calculate node position between node ports
 

--- a/qtpynodeeditor/node_geometry.py
+++ b/qtpynodeeditor/node_geometry.py
@@ -353,7 +353,7 @@ class NodeGeometry:
             # If the widget wants to use as much vertical space as possible,
             # place it immediately after the caption.
             return QPointF(self._spacing + self.port_width(PortType.input),
-                           self.caption_height())
+                           self.caption_height)
 
         if self._model.validation_state() != NodeValidationState.valid:
             return QPointF(
@@ -375,10 +375,10 @@ class NodeGeometry:
         -------
         value : int
         '''
-        base_height = self.height() - self.caption_height()
+        base_height = self.height() - self.caption_height
 
         if self._model.validation_state() != NodeValidationState.valid:
-            return (base_height + self.validation_height())
+            return base_height + self.validation_height
 
         return base_height
 

--- a/qtpynodeeditor/node_geometry.py
+++ b/qtpynodeeditor/node_geometry.py
@@ -58,13 +58,6 @@ class NodeGeometry:
 
     @width.setter
     def width(self, width: int):
-        """
-        Set width
-
-        Parameters
-        ----------
-        width : int
-        """
         self._width = int(width)
 
     @property
@@ -80,13 +73,6 @@ class NodeGeometry:
 
     @entry_height.setter
     def entry_height(self, h: int):
-        """
-        Set entry height
-
-        Parameters
-        ----------
-        h : int
-        """
         self._entry_height = int(h)
 
     @property
@@ -102,13 +88,6 @@ class NodeGeometry:
 
     @entry_width.setter
     def entry_width(self, width: int):
-        """
-        Set entry width
-
-        Parameters
-        ----------
-        width : int
-        """
         self._entry_width = int(width)
 
     @property
@@ -124,13 +103,6 @@ class NodeGeometry:
 
     @spacing.setter
     def spacing(self, s: int):
-        """
-        Set spacing
-
-        Parameters
-        ----------
-        s : int
-        """
         self._spacing = int(s)
 
     @property
@@ -146,19 +118,12 @@ class NodeGeometry:
 
     @hovered.setter
     def hovered(self, h: int):
-        """
-        Set hovered
-
-        Parameters
-        ----------
-        h : int
-        """
         self._hovered = bool(h)
 
     @property
     def num_sources(self) -> int:
         """
-        N sources
+        Number of sources.
 
         Returns
         -------
@@ -169,7 +134,7 @@ class NodeGeometry:
     @property
     def num_sinks(self) -> int:
         """
-        N sinks
+        Number of sinks.
 
         Returns
         -------
@@ -408,9 +373,13 @@ class NodeGeometry:
 
     @staticmethod
     def calculate_node_position_between_node_ports(
-            target_port_index: int, target_port: PortType, target_node:
-            NodeBase, source_port_index: int, source_port: PortType,
-            source_node: NodeBase, new_node: NodeBase) -> QPointF:
+            target_port_index: int,
+            target_port: PortType,
+            target_node: NodeBase,
+            source_port_index: int,
+            source_port: PortType,
+            source_node: NodeBase,
+            new_node: NodeBase) -> QPointF:
         """
         calculate node position between node ports
 

--- a/qtpynodeeditor/node_painter.py
+++ b/qtpynodeeditor/node_painter.py
@@ -1,15 +1,20 @@
 import math
+import typing
 
 from qtpy.QtCore import QPointF, QRectF, Qt
 from qtpy.QtGui import QFontMetrics, QLinearGradient, QPainter, QPen
 
-from .base import FlowSceneBase, NodeBase
 from .enums import NodeValidationState, PortType
 from .node_data import NodeDataModel
 from .node_geometry import NodeGeometry
 from .node_graphics_object import NodeGraphicsObject
 from .node_state import NodeState
 from .style import ConnectionStyle, NodeStyle
+
+if typing.TYPE_CHECKING:
+    from .connection import Connection  # noqa
+    from .flow_scene import FlowScene  # noqa
+    from .node import Node  # noqa
 
 
 class NodePainterDelegate:
@@ -28,7 +33,7 @@ class NodePainterDelegate:
 
 class NodePainter:
     @staticmethod
-    def paint(painter: QPainter, node: NodeBase, scene: FlowSceneBase,
+    def paint(painter: QPainter, node: 'Node', scene: 'FlowScene',
               node_style: NodeStyle, connection_style: ConnectionStyle):
         """
         Paint
@@ -171,7 +176,7 @@ class NodePainter:
     @staticmethod
     def draw_connection_points(painter: QPainter, geom: NodeGeometry,
                                state: NodeState, model: NodeDataModel,
-                               scene: FlowSceneBase, node_style: NodeStyle,
+                               scene: 'FlowScene', node_style: NodeStyle,
                                connection_style: ConnectionStyle
                                ):
         """

--- a/qtpynodeeditor/node_state.py
+++ b/qtpynodeeditor/node_state.py
@@ -1,9 +1,12 @@
+import typing
 from collections import OrderedDict
 
-from .base import ConnectionBase
 from .enums import ReactToConnectionState
 from .node_data import NodeDataType
 from .port import Port, PortType
+
+if typing.TYPE_CHECKING:
+    from .connection import Connection  # noqa
 
 
 class NodeState:
@@ -86,7 +89,7 @@ class NodeState:
         """
         return list(self._ports[port_type][port_index].connections)
 
-    def erase_connection(self, port_type: PortType, port_index: int, connection: ConnectionBase):
+    def erase_connection(self, port_type: PortType, port_index: int, connection: 'Connection'):
         """
         Erase connection
 

--- a/qtpynodeeditor/port.py
+++ b/qtpynodeeditor/port.py
@@ -35,6 +35,7 @@ class Port(QObject):
     connection_deleted = Signal(object)
     data_updated = Signal(QObject)
     data_invalidated = Signal(QObject)
+    _connections: typing.List['Connection']
 
     def __init__(self, node, *, port_type: PortType, index: int):
         super().__init__(parent=node)

--- a/qtpynodeeditor/port.py
+++ b/qtpynodeeditor/port.py
@@ -1,17 +1,38 @@
+import typing
+
 from qtpy.QtCore import QObject, Signal
 
-from .base import ConnectionBase
 from .enums import ConnectionPolicy, PortType
 
+if typing.TYPE_CHECKING:
+    from .connection import Connection  # noqa
 
-def opposite_port(port: PortType):
+
+def opposite_port(port: PortType) -> PortType:
+    """
+    Get the opposite port of `port`.
+
+    Parameters
+    ----------
+    port : PortType
+    """
     return {PortType.input: PortType.output,
             PortType.output: PortType.input}.get(port, PortType.none)
 
 
 class Port(QObject):
-    connection_created = Signal(ConnectionBase)
-    connection_deleted = Signal(ConnectionBase)
+    """
+
+    Signals
+    -------
+    connection_created : Signal(Connection)
+    connection_deleted : Signal(Connection)
+    data_updated : Signal(QObject)
+    data_invalidated : Signal(QObject)
+    """
+
+    connection_created = Signal(object)
+    connection_deleted = Signal(object)
     data_updated = Signal(QObject)
     data_invalidated = Signal(QObject)
 
@@ -79,7 +100,7 @@ class Port(QObject):
         else:
             return self.model.port_out_connection_policy(self.index)
 
-    def add_connection(self, connection: ConnectionBase):
+    def add_connection(self, connection: 'Connection'):
         'Add a Connection to the Port'
         if connection in self._connections:
             raise ValueError('Connection already in list')
@@ -87,7 +108,7 @@ class Port(QObject):
         self._connections.append(connection)
         self.connection_created.emit(connection)
 
-    def remove_connection(self, connection: ConnectionBase):
+    def remove_connection(self, connection: 'Connection'):
         'Remove a Connection from the Port'
         try:
             self._connections.remove(connection)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Fixes some mistakes when I had originally converted getters/setters to Python properties
* API: removed unnecessary base classes (*). Users shouldn't have been relying on this internal API anyway.
* Found other issues when re-running mypy; attempted to make it happier. Only a few things remain to fix around `None`/`Optional` handling, as far as I see (**).
* Cleaned up some bad and unnecessary docstrings

(*) I admittedly didn't have a clue what I was doing with Python type hints/type checking when initially writing this and didn't know how to get around circular import issues. That's largely fixed here with the conditional `typing.TYPE_CHECKING`.

## Motivation and Context
Closes #48 

<details>
<summary>(**) remaining mypy things to fix</summary>

```
qtpynodeeditor/node_connection_interaction.py:170: error: Item "None" of "Optional[NodeGraphicsObject]" has no attribute "move_connections"
qtpynodeeditor/node_connection_interaction.py:254: error: Item "None" of "Optional[NodeGraphicsObject]" has no attribute "sceneTransform"
qtpynodeeditor/node_connection_interaction.py:272: error: Item "None" of "Optional[NodeGraphicsObject]" has no attribute "sceneTransform"
qtpynodeeditor/node_painter.py:55: error: Argument 4 to "draw_node_rect" of "NodePainter" has incompatible type "Optional[NodeGraphicsObject]"; expected "NodeGraphicsObject"
qtpynodeeditor/node_painter.py:65: error: Argument 4 to "draw_validation_rect" of "NodePainter" has incompatible type "Optional[NodeGraphicsObject]"; expected "NodeGraphicsObject"
qtpynodeeditor/connection.py:36: error: Incompatible types in assignment (expression has type "Optional[Port]", variable has type "Port")
qtpynodeeditor/connection.py:175: error: Incompatible return value type (got "None", expected "ConnectionGraphicsObject")
qtpynodeeditor/connection.py:179: error: Incompatible types in assignment (expression has type "ConnectionGraphicsObject", variable has type "None")
qtpynodeeditor/connection.py:191: error: Item "None" of "Optional[Node]" has no attribute "graphics_object"
qtpynodeeditor/connection.py:191: error: Item "None" of "Union[NodeGraphicsObject, None, Any]" has no attribute "sceneTransform"
qtpynodeeditor/connection.py:192: error: Item "None" of "Optional[Node]" has no attribute "geometry"
qtpynodeeditor/connection.py:195: error: "None" has no attribute "setPos"
qtpynodeeditor/connection.py:197: error: "None" has no attribute "move"
qtpynodeeditor/connection.py:270: error: Item "None" of "Optional[Port]" has no attribute "index"
qtpynodeeditor/connection.py:285: error: Item "None" of "Optional[Port]" has no attribute "remove_connection"
qtpynodeeditor/connection.py:362: error: Item "None" of "Optional[Port]" has no attribute "node"
qtpynodeeditor/connection.py:367: error: Item "None" of "Optional[Port]" has no attribute "node"
qtpynodeeditor/connection.py:384: error: Incompatible return value type (got "None", expected "Node")
qtpynodeeditor/connection.py:397: error: Incompatible types in assignment (expression has type "Node", variable has type "None")
qtpynodeeditor/examples/calculator.py:5: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
qtpynodeeditor/examples/calculator.py:61: error: Dict entry 0 has incompatible type "str": "int"; expected "PortType": "int"
qtpynodeeditor/examples/calculator.py:62: error: Dict entry 1 has incompatible type "str": "int"; expected "PortType": "int"
qtpynodeeditor/examples/calculator.py:312: error: "NodeData" has no attribute "number_as_text"
qtpynodeeditor/tests/test_basic.py:22: error: Dict entry 0 has incompatible type "str": "int"; expected "PortType": "int"
qtpynodeeditor/tests/test_basic.py:23: error: Dict entry 1 has incompatible type "str": "int"; expected "PortType": "int"
qtpynodeeditor/tests/test_basic.py:44: error: Dict entry 0 has incompatible type "str": "int"; expected "PortType": "int"
qtpynodeeditor/tests/test_basic.py:45: error: Dict entry 1 has incompatible type "str": "int"; expected "PortType": "int"
```
</details>

## How Has This Been Tested?
* Test suite