### PR TITLE
solve issue 60, 'connection_created' signal called too early when cre…

### DIFF
--- a/qtpynodeeditor/connection_graphics_object.py
+++ b/qtpynodeeditor/connection_graphics_object.py
@@ -199,6 +199,7 @@ class ConnectionGraphicsObject(QGraphicsObject):
         interaction = NodeConnectionInteraction(node, self._connection, self._scene)
         if node and interaction.try_connect():
             node.reset_reaction_to_connection()
+            self._scene.connection_created.emit(self._connection)
 
         if self._connection.requires_port:
             self._scene.delete_connection(self._connection)

--- a/qtpynodeeditor/flow_scene.py
+++ b/qtpynodeeditor/flow_scene.py
@@ -514,11 +514,7 @@ class FlowScene(FlowSceneModel, QGraphicsScene):
         connection.graphics_object = cgo
         self._connections.append(connection)
 
-        if not port_a or not port_b:
-            # This connection isn't truly created yet. It's only partially
-            # created.  Thus, don't send the connection_created(...) signal.
-            connection.connection_completed.connect(self.connection_created.emit)
-        else:
+        if port_a and port_b:
             in_port, out_port = connection.ports
             out_port.node.on_data_updated(out_port)
             self.connection_created.emit(connection)


### PR DESCRIPTION
All the details are written in [`issue`](https://github.com/klauer/qtpynodeeditor/issues/60).