### PR TITLE
FIX: attempted fix for #63

### DIFF
--- a/qtpynodeeditor/node_graphics_object.py
+++ b/qtpynodeeditor/node_graphics_object.py
@@ -191,6 +191,7 @@ class NodeGraphicsObject(QGraphicsObject):
         state = self._node.state
         if self._node.model.resizable() and geom.resize_rect.contains(pos):
             state.resizing = True
+        self._scene.node_dragging.emit(True)
 
     def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent):
         """
@@ -236,8 +237,8 @@ class NodeGraphicsObject(QGraphicsObject):
         ----------
         event : QGraphicsSceneMouseEvent
         """
-        state = self._node.state
-        state.resizing = False
+        self._scene.node_dragging.emit(False)
+        self._node.state.resizing = False
         super().mouseReleaseEvent(event)
 
         # position connections precisely after fast node move


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
When multiple nodes are selected and dragged around the graphics scene, sometimes the final positions of the nodes are not taken into account by the connection graphics objects.

This attempted fix simply makes note of the (node) dragging status of the entire scene, and makes all nodes update their connections one final time (post-mouse-up).

## Motivation and Context
* Attempting to handle #63 
* Goal: release a minor tag today. Hoping this will suffice for the issue.

## How Has This Been Tested?
Interactively. It appears to fix the disconnect noted in #63 as best I can tell.

That said, it's still not as *smooth* as you'd like from a node editor.
I think the connection redrawing mechanism will need some refactoring to make that happen (specifically that connections should get redrawn in batches and not on an individual node basis... More for next time.)